### PR TITLE
Async read version

### DIFF
--- a/tiberius/Cargo.toml
+++ b/tiberius/Cargo.toml
@@ -21,7 +21,6 @@ thiserror = "1.0"
 bytes = "0.5"
 pretty-hex = "0.1"
 pin-project-lite = "0.1"
-pin-utils = "0.1.0-alpha.4"
 
 [dependencies.tokio-util]
 version = "0.3"

--- a/tiberius/Cargo.toml
+++ b/tiberius/Cargo.toml
@@ -20,6 +20,8 @@ parking_lot = "0.10"
 thiserror = "1.0"
 bytes = "0.5"
 pretty-hex = "0.1"
+pin-project-lite = "0.1"
+pin-utils = "0.1.0-alpha.4"
 
 [dependencies.tokio-util]
 version = "0.3"

--- a/tiberius/src/async_read_le_ext.rs
+++ b/tiberius/src/async_read_le_ext.rs
@@ -1,0 +1,170 @@
+use bytes::Buf;
+use pin_project_lite::pin_project;
+use std::io::ErrorKind::UnexpectedEof;
+use std::{future::Future, io, mem::size_of, pin::Pin, task};
+use task::Poll;
+use tokio::io::AsyncRead;
+
+macro_rules! le_reader {
+    ($name:ident, $ty:ty, $reader:ident) => {
+        le_reader!($name, $ty, $reader, size_of::<$ty>());
+    };
+    ($name:ident, $ty:ty, $reader:ident, $bytes:expr) => {
+        pin_project! {
+            #[doc(hidden)]
+            pub struct $name<R> {
+                #[pin]
+                src: R,
+                buf: [u8; $bytes],
+                read: u8,
+            }
+        }
+
+        #[allow(dead_code)]
+        impl<R> $name<R> {
+            pub(crate) fn new(src: R) -> Self {
+                $name {
+                    src,
+                    buf: [0; $bytes],
+                    read: 0,
+                }
+            }
+        }
+
+        impl<R> Future for $name<R>
+        where
+            R: AsyncRead,
+        {
+            type Output = io::Result<$ty>;
+
+            fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
+                let mut me = self.project();
+
+                if *me.read == $bytes as u8 {
+                    return Poll::Ready(Ok(Buf::$reader(&mut &me.buf[..])));
+                }
+
+                while *me.read < $bytes as u8 {
+                    *me.read += match me
+                        .src
+                        .as_mut()
+                        .poll_read(cx, &mut me.buf[*me.read as usize..])
+                    {
+                        Poll::Pending => return Poll::Pending,
+                        Poll::Ready(Err(e)) => return Poll::Ready(Err(e.into())),
+                        Poll::Ready(Ok(0)) => {
+                            return Poll::Ready(Err(UnexpectedEof.into()));
+                        }
+                        Poll::Ready(Ok(n)) => n as u8,
+                    };
+                }
+
+                let num = Buf::$reader(&mut &me.buf[..]);
+
+                Poll::Ready(Ok(num))
+            }
+        }
+    };
+}
+
+pub trait AsyncReadLeExt: AsyncRead {
+    fn read_f32<'a>(&'a mut self) -> ReadF32<&'a mut Self>
+    where
+        Self: Unpin,
+    {
+        ReadF32::new(self)
+    }
+
+    fn read_f64<'a>(&'a mut self) -> ReadF64<&'a mut Self>
+    where
+        Self: Unpin,
+    {
+        ReadF64::new(self)
+    }
+
+    fn read_f32_le<'a>(&'a mut self) -> ReadF32Le<&'a mut Self>
+    where
+        Self: Unpin,
+    {
+        ReadF32Le::new(self)
+    }
+
+    fn read_f64_le<'a>(&'a mut self) -> ReadF64Le<&'a mut Self>
+    where
+        Self: Unpin,
+    {
+        ReadF64Le::new(self)
+    }
+
+    fn read_u16_le<'a>(&'a mut self) -> ReadU16Le<&'a mut Self>
+    where
+        Self: Unpin,
+    {
+        ReadU16Le::new(self)
+    }
+
+    fn read_u32_le<'a>(&'a mut self) -> ReadU32Le<&'a mut Self>
+    where
+        Self: Unpin,
+    {
+        ReadU32Le::new(self)
+    }
+
+    fn read_u64_le<'a>(&'a mut self) -> ReadU64Le<&'a mut Self>
+    where
+        Self: Unpin,
+    {
+        ReadU64Le::new(self)
+    }
+
+    fn read_u128_le<'a>(&'a mut self) -> ReadU128Le<&'a mut Self>
+    where
+        Self: Unpin,
+    {
+        ReadU128Le::new(self)
+    }
+
+    fn read_i16_le<'a>(&'a mut self) -> ReadI16Le<&'a mut Self>
+    where
+        Self: Unpin,
+    {
+        ReadI16Le::new(self)
+    }
+
+    fn read_i32_le<'a>(&'a mut self) -> ReadI32Le<&'a mut Self>
+    where
+        Self: Unpin,
+    {
+        ReadI32Le::new(self)
+    }
+
+    fn read_i64_le<'a>(&'a mut self) -> ReadI64Le<&'a mut Self>
+    where
+        Self: Unpin,
+    {
+        ReadI64Le::new(self)
+    }
+
+    fn read_i128_le<'a>(&'a mut self) -> ReadI128Le<&'a mut Self>
+    where
+        Self: Unpin,
+    {
+        ReadI128Le::new(self)
+    }
+}
+
+le_reader!(ReadU16Le, u16, get_u16_le);
+le_reader!(ReadU32Le, u32, get_u32_le);
+le_reader!(ReadU64Le, u64, get_u64_le);
+le_reader!(ReadU128Le, u128, get_u128_le);
+
+le_reader!(ReadI16Le, i16, get_i16_le);
+le_reader!(ReadI32Le, i32, get_i32_le);
+le_reader!(ReadI64Le, i64, get_i64_le);
+le_reader!(ReadI128Le, i128, get_i128_le);
+
+le_reader!(ReadF32, f32, get_f32);
+le_reader!(ReadF64, f64, get_f64);
+
+le_reader!(ReadF32Le, f32, get_f32_le);
+le_reader!(ReadF64Le, f64, get_f64_le);

--- a/tiberius/src/client.rs
+++ b/tiberius/src/client.rs
@@ -165,7 +165,7 @@ impl Client {
         self.rpc_perform_query(RpcProcId::SpExecuteSQL, rpc_params, params)
             .await?;
 
-        Ok(QueryResult::new(&mut self.connection, self.context.clone()))
+        Ok(QueryResult::new(self.connection.token_stream()))
     }
 
     fn rpc_params<'a>(query: impl Into<Cow<'a, str>>) -> Vec<RpcParam<'a>> {

--- a/tiberius/src/client/connection.rs
+++ b/tiberius/src/client/connection.rs
@@ -303,6 +303,11 @@ impl AsyncRead for Connection {
                     this.flushed = packet.is_last();
                     let (_, payload) = packet.into_parts();
                     this.buf.extend(payload);
+
+                    if this.buf.len() < size {
+                        cx.waker().wake_by_ref();
+                        return Poll::Pending;
+                    }
                 }
                 Some(Err(e)) => {
                     return Poll::Ready(Err(io::Error::new(

--- a/tiberius/src/client/connection.rs
+++ b/tiberius/src/client/connection.rs
@@ -1,8 +1,9 @@
 use crate::{
+    async_read_le_ext::AsyncReadLeExt,
     client::AuthMethod,
     protocol::{
         codec::{self, Encode, LoginMessage, Packet, PacketHeader, PacketStatus, PreloginMessage},
-        stream::TokenStream,
+        stream::{ReceivedToken, TokenStream},
         Context, HEADER_BYTES,
     },
     tls::MaybeTlsStream,
@@ -12,12 +13,13 @@ use bytes::BytesMut;
 use codec::PacketCodec;
 use futures::{ready, SinkExt, Stream, TryStream, TryStreamExt};
 use std::{
-    cmp,
+    cmp, io,
     pin::Pin,
     sync::{atomic::Ordering, Arc},
     task,
 };
 use task::Poll;
+use tokio::io::AsyncRead;
 use tokio_util::codec::Framed;
 use tracing::{event, Level};
 #[cfg(windows)]
@@ -36,6 +38,7 @@ pub struct Connection {
     transport: Framed<MaybeTlsStream, PacketCodec>,
     flushed: bool,
     context: Arc<Context>,
+    buf: BytesMut,
 }
 
 impl Connection {
@@ -48,6 +51,7 @@ impl Connection {
             transport,
             context,
             flushed: false,
+            buf: BytesMut::new(),
         }
     }
 
@@ -105,6 +109,8 @@ impl Connection {
     /// Calling this will slow down the queries if stream is still dirty, so
     /// using all the results after querying must be handled properly.
     pub(crate) async fn flush_stream(&mut self) -> crate::Result<()> {
+        self.buf.truncate(0);
+
         if self.flushed {
             return Ok(());
         }
@@ -165,7 +171,9 @@ impl Connection {
                 msg.integrated_security = buf;
 
                 self.send(PacketHeader::login(&self.context), msg).await?;
-                self.token_stream().flush_done().await?;
+
+                let ts = TokenStream::new(self, self.context.clone());
+                ts.flush_done().await?;
 
                 let mut ts = self.token_stream();
                 let sspi_bytes = ts.flush_sspi().await?;
@@ -199,7 +207,9 @@ impl Connection {
                 msg.password = password.into();
 
                 self.send(PacketHeader::login(&self.context), msg).await?;
-                self.token_stream().flush_done().await?;
+
+                let ts = TokenStream::new(self, self.context.clone());
+                ts.flush_done().await?;
             }
             x => panic!("Auth method not supported {:?}", x),
         }
@@ -240,6 +250,7 @@ impl Connection {
                 transport,
                 context: self.context,
                 flushed: false,
+                buf: BytesMut::new(),
             })
         } else {
             Ok(self)
@@ -253,8 +264,10 @@ impl Connection {
         Ok(self)
     }
 
-    pub(crate) fn token_stream(&mut self) -> TokenStream<Connection> {
-        TokenStream::new(self, self.context.clone())
+    pub(crate) fn token_stream<'a>(
+        &'a mut self,
+    ) -> Box<dyn Stream<Item = crate::Result<ReceivedToken>> + 'a> {
+        TokenStream::new(self, self.context.clone()).try_unfold()
     }
 }
 
@@ -264,7 +277,7 @@ impl Stream for Connection {
     fn poll_next(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
 
-        match ready!(Pin::new(&mut this.transport).try_poll_next(cx)) {
+        match ready!(this.transport.try_poll_next_unpin(cx)) {
             Some(Ok(packet)) => {
                 this.flushed = packet.is_last();
                 Poll::Ready(Some(Ok(packet)))
@@ -274,3 +287,41 @@ impl Stream for Connection {
         }
     }
 }
+
+impl AsyncRead for Connection {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut task::Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        let this = self.get_mut();
+        let size = buf.len();
+
+        if this.buf.len() < size {
+            match ready!(Pin::new(&mut this.transport).try_poll_next(cx)) {
+                Some(Ok(packet)) => {
+                    this.flushed = packet.is_last();
+                    let (_, payload) = packet.into_parts();
+                    this.buf.extend(payload);
+                }
+                Some(Err(e)) => {
+                    return Poll::Ready(Err(io::Error::new(
+                        io::ErrorKind::BrokenPipe,
+                        e.to_string(),
+                    )))
+                }
+                None => {
+                    return Poll::Ready(Err(io::Error::new(
+                        io::ErrorKind::UnexpectedEof,
+                        "No more packets in the wire",
+                    )))
+                }
+            }
+        }
+
+        buf.copy_from_slice(this.buf.split_to(size).as_ref());
+        Poll::Ready(Ok(size))
+    }
+}
+
+impl AsyncReadLeExt for Connection {}

--- a/tiberius/src/lib.rs
+++ b/tiberius/src/lib.rs
@@ -3,6 +3,7 @@
 
 use protocol::codec::*;
 
+mod async_read_le_ext;
 mod client;
 mod prepared;
 

--- a/tiberius/src/protocol/codec/token/token_error.rs
+++ b/tiberius/src/protocol/codec/token/token_error.rs
@@ -1,9 +1,12 @@
-use crate::protocol::{
-    codec::{read_varchar, BytesData, Decode, FeatureLevel},
-    Context,
+use crate::{
+    async_read_le_ext::AsyncReadLeExt,
+    protocol::{
+        codec::{read_varchar, FeatureLevel},
+        Context,
+    },
 };
-use bytes::Buf;
 use std::fmt;
+use tokio::io::AsyncReadExt;
 
 #[derive(Clone, Debug, thiserror::Error)]
 pub struct TokenError {
@@ -20,39 +23,29 @@ pub struct TokenError {
     pub(crate) line: u32,
 }
 
-impl fmt::Display for TokenError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "'{}' on server {} executing {} on line {} (code: {}, state: {}, class: {})",
-            self.message, self.server, self.procedure, self.line, self.code, self.state, self.class
-        )
-    }
-}
-
-impl<'a> Decode<BytesData<'a, Context>> for TokenError {
-    fn decode(src: &mut BytesData<'a, Context>) -> crate::Result<Self>
+impl TokenError {
+    pub(crate) async fn decode<R>(src: &mut R, ctx: &Context) -> crate::Result<Self>
     where
-        Self: Sized,
+        R: AsyncReadLeExt + Unpin,
     {
-        let _length = src.get_u16_le() as usize;
-        let code = src.get_u32_le();
-        let state = src.get_u8();
-        let class = src.get_u8();
+        let _length = src.read_u16_le().await? as usize;
+        let code = src.read_u32_le().await?;
+        let state = src.read_u8().await?;
+        let class = src.read_u8().await?;
 
-        let message_len = src.get_u16_le();
-        let message = read_varchar(src, message_len)?;
+        let message_len = src.read_u16_le().await?;
+        let message = read_varchar(src, message_len).await?;
 
-        let server_len = src.get_u8();
-        let server = read_varchar(src, server_len)?;
+        let server_len = src.read_u8().await?;
+        let server = read_varchar(src, server_len).await?;
 
-        let procedure_len = src.get_u8();
-        let procedure = read_varchar(src, procedure_len)?;
+        let procedure_len = src.read_u8().await?;
+        let procedure = read_varchar(src, procedure_len).await?;
 
-        let line = if src.context().version > FeatureLevel::SqlServer2005 {
-            src.get_u32_le()
+        let line = if ctx.version > FeatureLevel::SqlServer2005 {
+            src.read_u32_le().await?
         } else {
-            src.get_u16_le() as u32
+            src.read_u16_le().await? as u32
         };
 
         let token = TokenError {
@@ -66,5 +59,15 @@ impl<'a> Decode<BytesData<'a, Context>> for TokenError {
         };
 
         Ok(token)
+    }
+}
+
+impl fmt::Display for TokenError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "'{}' on server {} executing {} on line {} (code: {}, state: {}, class: {})",
+            self.message, self.server, self.procedure, self.line, self.code, self.state, self.class
+        )
     }
 }

--- a/tiberius/src/protocol/codec/token/token_order.rs
+++ b/tiberius/src/protocol/codec/token/token_order.rs
@@ -1,22 +1,21 @@
-use crate::protocol::codec::Decode;
-use bytes::{Buf, BytesMut};
+use crate::async_read_le_ext::AsyncReadLeExt;
 
 #[derive(Debug)]
 pub struct TokenOrder {
     pub(crate) column_indexes: Vec<u16>,
 }
 
-impl Decode<BytesMut> for TokenOrder {
-    fn decode(src: &mut BytesMut) -> crate::Result<Self>
+impl TokenOrder {
+    pub(crate) async fn decode<R>(src: &mut R) -> crate::Result<Self>
     where
-        Self: Sized,
+        R: AsyncReadLeExt + Unpin,
     {
-        let len = src.get_u16_le() / 2;
+        let len = src.read_u16_le().await? / 2;
 
         let mut column_indexes = Vec::with_capacity(len as usize);
 
         for _ in 0..len {
-            column_indexes.push(src.get_u16_le());
+            column_indexes.push(src.read_u16_le().await?);
         }
 
         Ok(TokenOrder { column_indexes })

--- a/tiberius/src/protocol/codec/token/token_row.rs
+++ b/tiberius/src/protocol/codec/token/token_row.rs
@@ -1,8 +1,36 @@
-use crate::protocol::codec::{ColumnData, TokenColMetaData};
+use crate::{
+    async_read_le_ext::AsyncReadLeExt,
+    protocol::{
+        codec::{ColumnData, TokenColMetaData},
+        Context,
+    },
+};
 use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct TokenRow {
     pub meta: Arc<TokenColMetaData>,
     pub columns: Vec<ColumnData<'static>>,
+}
+
+impl TokenRow {
+    pub(crate) async fn decode<R>(src: &mut R, ctx: &Context) -> crate::Result<Self>
+    where
+        R: AsyncReadLeExt + Unpin,
+    {
+        let col_meta = ctx.last_meta.lock().clone().unwrap();
+
+        let mut row = TokenRow {
+            meta: col_meta.clone(),
+            columns: Vec::with_capacity(col_meta.columns.len()),
+        };
+
+        for column in col_meta.columns.iter() {
+            let data = ColumnData::decode(src, &column.base.ty).await?;
+
+            row.columns.push(data);
+        }
+
+        Ok(row)
+    }
 }

--- a/tiberius/src/protocol/codec/token/token_sspi.rs
+++ b/tiberius/src/protocol/codec/token/token_sspi.rs
@@ -10,6 +10,16 @@ impl AsRef<[u8]> for TokenSSPI {
     }
 }
 
+impl TokenSSPI {
+    pub(crate) async fn decode_async<R>(src: &mut R) -> crate::Result<Self>
+    where
+        R: AsyncReadLeExt + Unpin,
+    {
+        let len = src.read_u16_le().await?;
+        Ok(Self(src.split_to(len as usize).to_vec()))
+    }
+}
+
 impl Decode<BytesMut> for TokenSSPI {
     fn decode(src: &mut BytesMut) -> crate::Result<Self>
     where

--- a/tiberius/src/protocol/codec/token/token_type.rs
+++ b/tiberius/src/protocol/codec/token/token_type.rs
@@ -1,6 +1,4 @@
-use crate::{protocol::codec::Decode, uint_enum, Error};
-use bytes::{Buf, BytesMut};
-use std::convert::TryFrom;
+use crate::uint_enum;
 
 uint_enum! {
     /// Types of tokens in a token stream. Read from the first byte of the stream.
@@ -85,19 +83,5 @@ uint_enum! {
         ///
         /// Length: 8 or 12 bytes (after SQL Server 2005)
         DoneInProc = 0xFF,
-    }
-}
-
-impl Decode<BytesMut> for TokenType {
-    fn decode(src: &mut BytesMut) -> crate::Result<Self>
-    where
-        Self: Sized,
-    {
-        let ty_byte = src.get_u8();
-
-        let ty = TokenType::try_from(ty_byte)
-            .map_err(|_| Error::Protocol(format!("invalid token type {:x}", ty_byte).into()))?;
-
-        Ok(ty)
     }
 }

--- a/tiberius/src/protocol/stream/prepared.rs
+++ b/tiberius/src/protocol/stream/prepared.rs
@@ -1,36 +1,26 @@
-use super::{ReceivedToken, TokenStream};
-use crate::protocol::{
-    codec::{DoneStatus, Packet},
-    Context,
-};
-use futures::{ready, Stream, StreamExt};
+use super::ReceivedToken;
+use crate::protocol::codec::DoneStatus;
+use futures::{ready, Stream};
 use std::{
     pin::Pin,
-    sync::Arc,
     task::{self, Poll},
 };
 
-pub(crate) struct PreparedStream<'a, S> {
-    token_stream: TokenStream<'a, S>,
+pub(crate) struct PreparedStream<'a> {
+    token_stream: Box<dyn Stream<Item = crate::Result<ReceivedToken>> + 'a>,
     read_ahead: Option<ReceivedToken>,
 }
 
-impl<'a, S> PreparedStream<'a, S>
-where
-    S: Stream<Item = crate::Result<Packet>> + Unpin + 'a,
-{
-    pub fn new(packet_stream: &'a mut S, context: Arc<Context>) -> Self {
+impl<'a> PreparedStream<'a> {
+    pub fn new(token_stream: Box<dyn Stream<Item = crate::Result<ReceivedToken>> + 'a>) -> Self {
         Self {
-            token_stream: TokenStream::new(packet_stream, context),
+            token_stream,
             read_ahead: None,
         }
     }
 }
 
-impl<'a, S> Stream for PreparedStream<'a, S>
-where
-    S: Stream<Item = crate::Result<Packet>> + Unpin + 'a,
-{
+impl<'a> Stream for PreparedStream<'a> {
     type Item = crate::Result<ReceivedToken>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Option<Self::Item>> {
@@ -39,7 +29,8 @@ where
                 return Poll::Ready(Some(Ok(self.read_ahead.take().unwrap())));
             }
 
-            let item = match ready!(self.token_stream.poll_next_unpin(cx)) {
+            let stream = unsafe { Pin::new_unchecked(&mut *self.token_stream) };
+            let item = match ready!(stream.poll_next(cx)) {
                 Some(res) => res?,
                 None => return Poll::Ready(None),
             };

--- a/tiberius/src/protocol/stream/token.rs
+++ b/tiberius/src/protocol/stream/token.rs
@@ -1,26 +1,23 @@
 #[cfg(windows)]
 use super::codec::TokenSSPI;
-
 use crate::{
+    async_read_le_ext::AsyncReadLeExt,
     protocol::{
         codec::{
-            BytesData, ColumnData, Decode, FixedLenType, Packet, TokenColMetaData, TokenDone,
-            TokenEnvChange, TokenError, TokenInfo, TokenLoginAck, TokenOrder, TokenReturnValue,
-            TokenRow, TypeInfo, VarLenType, VariableLengthContext, VariableLengthPrecisionContext,
+            TokenColMetaData, TokenDone, TokenEnvChange, TokenError, TokenInfo, TokenLoginAck,
+            TokenOrder, TokenReturnValue, TokenRow,
         },
         Context,
     },
     Error, TokenType,
 };
-use bytes::{Buf, BytesMut};
-use futures::{ready, Stream, TryStream, TryStreamExt};
+use futures::{Stream, TryStreamExt};
 use std::{
     convert::TryFrom,
     pin::Pin,
     sync::{atomic::Ordering, Arc},
-    task,
 };
-use task::Poll;
+use tokio::io::AsyncReadExt;
 use tracing::{event, Level};
 
 #[derive(Debug)]
@@ -41,32 +38,29 @@ pub enum ReceivedToken {
 }
 
 pub(crate) struct TokenStream<'a, S> {
-    packet_stream: Pin<&'a mut S>,
+    conn: &'a mut S,
     context: Arc<Context>,
-    buf: BytesMut,
-    has_more_data: bool,
-    row_cache: Vec<ColumnData<'static>>,
-    handling_row: bool,
+    row_mode: bool,
 }
 
 impl<'a, S> TokenStream<'a, S>
 where
-    S: Stream<Item = crate::Result<Packet>> + Unpin + 'a,
+    S: AsyncReadLeExt + Unpin + 'a,
 {
-    pub(crate) fn new(packet_stream: &'a mut S, context: Arc<Context>) -> Self {
+    pub(crate) fn new(conn: &'a mut S, context: Arc<Context>) -> Self {
         Self {
-            packet_stream: Pin::new(packet_stream),
+            conn,
             context,
-            buf: BytesMut::new(),
-            has_more_data: true,
-            row_cache: Vec::new(),
-            handling_row: false,
+            row_mode: false,
         }
     }
 
-    pub(crate) async fn flush_done(&mut self) -> crate::Result<TokenDone> {
+    pub(crate) async fn flush_done(self) -> crate::Result<TokenDone> {
+        let mut stream = self.try_unfold();
+        let mut stream = unsafe { Pin::new_unchecked(&mut *stream) };
+
         loop {
-            match self.try_next().await? {
+            match stream.try_next().await? {
                 Some(ReceivedToken::Done(token)) => return Ok(token),
                 Some(_) => (),
                 None => return Err(crate::Error::Protocol("Never got DONE token.".into())),
@@ -75,9 +69,12 @@ where
     }
 
     #[cfg(windows)]
-    pub(crate) async fn flush_sspi(&mut self) -> crate::Result<TokenSSPI> {
+    pub(crate) async fn flush_sspi(self) -> crate::Result<TokenSSPI> {
+        let mut stream = self.try_unfold();
+        let mut stream = unsafe { Pin::new_unchecked(&mut *stream) };
+
         loop {
-            match self.try_next().await? {
+            match stream.try_next().await? {
                 Some(ReceivedToken::SSPI(token)) => return Ok(token),
                 Some(_) => (),
                 None => return Err(crate::Error::Protocol("Never got SSPI token.".into())),
@@ -85,9 +82,8 @@ where
         }
     }
 
-    fn get_col_metadata(&mut self) -> crate::Result<ReceivedToken> {
-        let meta = Arc::new(TokenColMetaData::decode(&mut self.buf)?);
-        self.row_cache.reserve(meta.columns.len());
+    async fn get_col_metadata(&mut self) -> crate::Result<ReceivedToken> {
+        let meta = Arc::new(TokenColMetaData::decode(self.conn).await?);
         self.context.set_last_meta(meta.clone());
 
         event!(Level::TRACE, ?meta);
@@ -95,125 +91,58 @@ where
         Ok(ReceivedToken::NewResultset(meta))
     }
 
-    fn try_fill_buffer(
-        &mut self,
-        expected_size: usize,
-        cx: &mut task::Context<'_>,
-    ) -> Poll<crate::Result<()>> {
-        if self.has_more_data && self.buf.len() < expected_size {
-            if let Poll::Pending = self.fetch_packet(cx) {
-                return Poll::Pending;
-            }
-        }
+    async fn get_row(&mut self) -> crate::Result<ReceivedToken> {
+        self.row_mode = true;
+        let return_value = TokenRow::decode(self.conn, &self.context).await?;
+        self.row_mode = false;
 
-        if self.buf.len() < expected_size {
-            return Poll::Pending;
-        }
-
-        Poll::Ready(Ok(()))
+        event!(Level::TRACE, message = ?return_value);
+        Ok(ReceivedToken::Row(return_value))
     }
 
-    fn poll_row(&mut self, cx: &mut task::Context<'_>) -> Poll<crate::Result<TokenRow>> {
-        self.handling_row = true;
-        let col_meta = self.context.last_meta.lock().clone().unwrap();
-        let handled_columns = self.row_cache.len();
-
-        for column in col_meta.columns.iter().skip(handled_columns) {
-            let data = match column.base.ty {
-                TypeInfo::FixedLen(fixed_ty) => {
-                    ready!(self.try_fill_buffer(fixed_ty.len(), cx))?;
-                    let mut src: BytesData<FixedLenType> = BytesData::new(&mut self.buf, &fixed_ty);
-                    ColumnData::decode(&mut src)?
-                }
-                TypeInfo::VarLenSized(ty, max_len, collation) => {
-                    let size = ty.get_size(max_len, &self.buf);
-                    ready!(self.try_fill_buffer(size, cx))?;
-
-                    let context = VariableLengthContext::new(ty, max_len, collation);
-
-                    let mut src: BytesData<VariableLengthContext> =
-                        BytesData::new(&mut self.buf, &context);
-
-                    ColumnData::decode(&mut src)?
-                }
-                TypeInfo::VarLenSizedPrecision { ty, scale, .. } => match ty {
-                    VarLenType::Decimaln | VarLenType::Numericn => {
-                        let size = self.buf[0] as usize;
-                        ready!(self.try_fill_buffer(size, cx))?;
-
-                        let context = VariableLengthPrecisionContext { scale };
-                        let mut src = BytesData::new(&mut self.buf, &context);
-
-                        ColumnData::decode(&mut src)?
-                    }
-                    _ => todo!(),
-                },
-            };
-
-            self.row_cache.push(data);
-        }
-
-        if col_meta.columns.len() == self.row_cache.len() {
-            self.handling_row = false;
-
-            let row = TokenRow {
-                meta: col_meta,
-                columns: self.row_cache.drain(..).collect(),
-            };
-
-            Poll::Ready(Ok(row))
-        } else {
-            Poll::Pending
-        }
-    }
-
-    fn get_return_value(&mut self) -> crate::Result<ReceivedToken> {
-        let return_value = TokenReturnValue::decode(&mut self.buf)?;
+    async fn get_return_value(&mut self) -> crate::Result<ReceivedToken> {
+        let return_value = TokenReturnValue::decode(self.conn).await?;
         event!(Level::TRACE, message = ?return_value);
         Ok(ReceivedToken::ReturnValue(return_value))
     }
 
-    fn get_return_status(&mut self) -> crate::Result<ReceivedToken> {
-        let status = self.buf.get_u32_le();
+    async fn get_return_status(&mut self) -> crate::Result<ReceivedToken> {
+        let status = self.conn.read_u32_le().await?;
         Ok(ReceivedToken::ReturnStatus(status))
     }
 
-    fn get_error(&mut self) -> crate::Result<ReceivedToken> {
-        let mut src = BytesData::new(&mut self.buf, &*self.context);
-        let err = TokenError::decode(&mut src)?;
+    async fn get_error(&mut self) -> crate::Result<ReceivedToken> {
+        let err = TokenError::decode(self.conn, &self.context).await?;
         event!(Level::ERROR, message = %err.message, code = err.code);
         Err(Error::Server(err))
     }
 
-    fn get_order(&mut self) -> crate::Result<ReceivedToken> {
-        let order = TokenOrder::decode(&mut self.buf)?;
+    async fn get_order(&mut self) -> crate::Result<ReceivedToken> {
+        let order = TokenOrder::decode(self.conn).await?;
         event!(Level::TRACE, message = ?order);
         Ok(ReceivedToken::Order(order))
     }
 
-    fn get_done_value(&mut self) -> crate::Result<ReceivedToken> {
-        let mut src = BytesData::new(&mut self.buf, &*self.context);
-        let done = TokenDone::decode(&mut src)?;
+    async fn get_done_value(&mut self) -> crate::Result<ReceivedToken> {
+        let done = TokenDone::decode(self.conn, &*self.context).await?;
         event!(Level::TRACE, "{}", done);
         Ok(ReceivedToken::Done(done))
     }
 
-    fn get_done_proc_value(&mut self) -> crate::Result<ReceivedToken> {
-        let mut src = BytesData::new(&mut self.buf, &*self.context);
-        let done = TokenDone::decode(&mut src)?;
+    async fn get_done_proc_value(&mut self) -> crate::Result<ReceivedToken> {
+        let done = TokenDone::decode(self.conn, &*self.context).await?;
         event!(Level::TRACE, "{}", done);
         Ok(ReceivedToken::DoneProc(done))
     }
 
-    fn get_done_in_proc_value(&mut self) -> crate::Result<ReceivedToken> {
-        let mut src = BytesData::new(&mut self.buf, &*self.context);
-        let done = TokenDone::decode(&mut src)?;
+    async fn get_done_in_proc_value(&mut self) -> crate::Result<ReceivedToken> {
+        let done = TokenDone::decode(self.conn, &*self.context).await?;
         event!(Level::TRACE, "{}", done);
         Ok(ReceivedToken::DoneInProc(done))
     }
 
-    fn get_env_change(&mut self) -> crate::Result<ReceivedToken> {
-        let change = TokenEnvChange::decode(&mut self.buf)?;
+    async fn get_env_change(&mut self) -> crate::Result<ReceivedToken> {
+        let change = TokenEnvChange::decode(self.conn).await?;
 
         if let TokenEnvChange::PacketSize(new_size, _) = change {
             self.context.packet_size.store(new_size, Ordering::SeqCst);
@@ -224,109 +153,60 @@ where
         Ok(ReceivedToken::EnvChange(change))
     }
 
-    fn get_info(&mut self) -> crate::Result<ReceivedToken> {
-        let info = TokenInfo::decode(&mut self.buf)?;
+    async fn get_info(&mut self) -> crate::Result<ReceivedToken> {
+        let info = TokenInfo::decode(self.conn).await?;
         event!(Level::INFO, "{}", info.message);
         Ok(ReceivedToken::Info(info))
     }
 
-    fn get_login_ack(&mut self) -> crate::Result<ReceivedToken> {
-        let ack = TokenLoginAck::decode(&mut self.buf)?;
+    async fn get_login_ack(&mut self) -> crate::Result<ReceivedToken> {
+        let ack = TokenLoginAck::decode(self.conn).await?;
         event!(Level::INFO, "{} version {}", ack.prog_name, ack.version);
         Ok(ReceivedToken::LoginAck(ack))
     }
 
     #[cfg(windows)]
-    fn get_sspi(&mut self) -> crate::Result<ReceivedToken> {
-        let sspi = TokenSSPI::decode(&mut self.buf)?;
+    async fn get_sspi(&mut self) -> crate::Result<ReceivedToken> {
+        let sspi = TokenSSPI::decode(self.conn).await?;
         event!(Level::INFO, "SSPI response");
         Ok(ReceivedToken::SSPI(sspi))
     }
 
-    fn fetch_packet(&mut self, cx: &mut task::Context<'_>) -> Poll<Option<crate::Result<()>>> {
-        if self.has_more_data {
-            match ready!(self.packet_stream.as_mut().try_poll_next(cx)?) {
-                Some(packet) => {
-                    self.has_more_data = !packet.is_last();
-                    let (_, payload) = packet.into_parts();
-                    self.buf.extend(payload);
+    pub fn try_unfold(self) -> Box<dyn Stream<Item = crate::Result<ReceivedToken>> + 'a> {
+        let s = futures::stream::try_unfold((self, true), |(mut this, more_data)| async move {
+            if !more_data {
+                return Ok(None);
+            }
 
-                    Poll::Ready(Some(Ok(())))
+            let ty_byte = this.conn.read_u8().await?;
+
+            let ty = TokenType::try_from(ty_byte)
+                .map_err(|_| Error::Protocol(format!("invalid token type {:x}", ty_byte).into()))?;
+
+            let token = match ty {
+                TokenType::ReturnStatus => this.get_return_status().await?,
+                TokenType::ColMetaData => this.get_col_metadata().await?,
+                TokenType::Row => this.get_row().await?,
+                TokenType::Done => {
+                    let result = this.get_done_value().await?;
+                    return Ok(Some((result, (this, false))));
                 }
-                _ => Poll::Ready(None),
-            }
-        } else {
-            Poll::Ready(None)
-        }
-    }
+                TokenType::DoneProc => this.get_done_proc_value().await?,
+                TokenType::DoneInProc => this.get_done_in_proc_value().await?,
+                TokenType::ReturnValue => this.get_return_value().await?,
+                TokenType::Error => this.get_error().await?,
+                TokenType::Order => this.get_order().await?,
+                TokenType::EnvChange => this.get_env_change().await?,
+                TokenType::Info => this.get_info().await?,
+                TokenType::LoginAck => this.get_login_ack().await?,
+                #[cfg(windows)]
+                TokenType::SSPI => this.get_sspi().await?,
+                _ => panic!("Token {:?} unimplemented!", ty),
+            };
 
-    fn enough_data_for(&self, ty: TokenType) -> bool {
-        use TokenType::*;
+            Ok(Some((token, (this, true))))
+        });
 
-        match ty {
-            ReturnStatus => self.buf.len() >= 4,
-            Error | Info | Order | ColInfo | ReturnValue | LoginAck | SSPI | EnvChange
-            | ColMetaData => {
-                let len = (&self.buf[0..2]).get_u16_le() as usize + 2;
-                self.buf.len() >= len
-            }
-            Row => {
-                true // we handle the size checks per column
-            }
-            Done | DoneProc | DoneInProc => {
-                let len = self.context.version.done_row_count_bytes() as usize + 4;
-                self.buf.len() >= len
-            }
-            x => panic!("Token type {:?} not supported", x),
-        }
-    }
-}
-
-impl<'a, S> Stream for TokenStream<'a, S>
-where
-    S: Stream<Item = crate::Result<Packet>> + Unpin + 'a,
-{
-    type Item = crate::Result<ReceivedToken>;
-
-    fn poll_next(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Option<Self::Item>> {
-        let this = self.get_mut();
-
-        if this.buf.is_empty() {
-            ready!(this.fetch_packet(cx));
-        }
-
-        let ty = if this.handling_row {
-            TokenType::Row
-        } else {
-            let ty_byte = this.buf.get_u8();
-
-            TokenType::try_from(ty_byte)
-                .map_err(|_| Error::Protocol(format!("invalid token type {:x}", ty_byte).into()))?
-        };
-
-        while this.has_more_data && !this.enough_data_for(ty) {
-            ready!(this.fetch_packet(cx));
-        }
-
-        match ty {
-            TokenType::ReturnStatus => Poll::Ready(Some(this.get_return_status())),
-            TokenType::ColMetaData => Poll::Ready(Some(this.get_col_metadata())),
-            TokenType::Row => {
-                let row = ready!(this.poll_row(cx))?;
-                Poll::Ready(Some(Ok(ReceivedToken::Row(row))))
-            }
-            TokenType::Done => Poll::Ready(Some(this.get_done_value())),
-            TokenType::DoneProc => Poll::Ready(Some(this.get_done_proc_value())),
-            TokenType::DoneInProc => Poll::Ready(Some(this.get_done_in_proc_value())),
-            TokenType::ReturnValue => Poll::Ready(Some(this.get_return_value())),
-            TokenType::Error => Poll::Ready(Some(this.get_error())),
-            TokenType::Order => Poll::Ready(Some(this.get_order())),
-            TokenType::EnvChange => Poll::Ready(Some(this.get_env_change())),
-            TokenType::Info => Poll::Ready(Some(this.get_info())),
-            TokenType::LoginAck => Poll::Ready(Some(this.get_login_ack())),
-            #[cfg(windows)]
-            TokenType::SSPI => Poll::Ready(Some(this.get_sspi())),
-            _ => panic!("Token {:?} unimplemented!", ty),
-        }
+        Box::new(s)
     }
 }

--- a/tiberius/tests/query.rs
+++ b/tiberius/tests/query.rs
@@ -72,7 +72,7 @@ async fn test_kanji_varchars() -> Result<()> {
         .await?;
 
     let kanji = "余ったものを後で皆に分けようと思っていただけなのに".to_string();
-    let long_kanji = "余".repeat(8001);
+    let long_kanji = "余".repeat(80001);
 
     let res = conn
         .execute(
@@ -132,29 +132,35 @@ async fn test_execute() -> Result<()> {
     conn.execute("CREATE TABLE ##TestExecute (id int)", &[])
         .await?;
 
-    let mut insert_count = conn
+    let insert_count = conn
         .execute(
             "INSERT INTO ##TestExecute (id) VALUES (@P1), (@P2), (@P3)",
             &[&1i32, &2i32, &3i32],
         )
+        .await?
+        .total()
         .await?;
 
-    assert_eq!(Some(3), insert_count.try_next().await?);
+    assert_eq!(3, insert_count);
 
-    let mut update_count = conn
+    let update_count = conn
         .execute(
             "UPDATE ##TestExecute SET id = @P1 WHERE id = @P2",
             &[&2i32, &1i32],
         )
+        .await?
+        .total()
         .await?;
 
-    assert_eq!(Some(1), update_count.try_next().await?);
+    assert_eq!(1, update_count);
 
-    let mut delete_count = conn
+    let delete_count = conn
         .execute("DELETE ##TestExecute WHERE id <> @P1", &[&3i32])
+        .await?
+        .total()
         .await?;
 
-    assert_eq!(Some(2), delete_count.try_next().await?);
+    assert_eq!(2, delete_count);
 
     Ok(())
 }


### PR DESCRIPTION
Instead of polling until we get enough packets for the token, while approximating its size, we implement `AsyncRead` for the connection, that buffers packets when needed and allows decoders to read bytes from it. This fixes problems with tokens of unknown size, such as `TEXT` or `XML`.