### PR TITLE
Exec result

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -136,14 +136,14 @@ impl Client {
         &'a mut self,
         query: impl Into<Cow<'_, str>>,
         params: &'b [&'b dyn ToSql],
-    ) -> crate::Result<ExecuteResult<'a>> {
+    ) -> crate::Result<ExecuteResult> {
         self.connection.flush_stream().await?;
         let rpc_params = Self::rpc_params(query);
 
         self.rpc_perform_query(RpcProcId::SpExecuteSQL, rpc_params, params)
             .await?;
 
-        Ok(ExecuteResult::new(&mut self.connection))
+        Ok(ExecuteResult::try_new(&mut self.connection).await?)
     }
 
     /// Executes SQL statements in the SQL Server, returning resulting rows.

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -84,7 +84,7 @@ async fn test_kanji_varchars() -> Result<()> {
         )
         .await?;
 
-    assert_eq!(2, res.total().await?);
+    assert_eq!(2, res.total());
 
     let stream = conn.query("SELECT content FROM ##TestKanji", &[]).await?;
 
@@ -114,7 +114,7 @@ async fn test_finnish_varchars() -> Result<()> {
         )
         .await?;
 
-    assert_eq!(1, res.total().await?);
+    assert_eq!(1, res.total());
 
     let stream = conn.query("SELECT content FROM ##TestFinnish", &[]).await?;
 
@@ -141,8 +141,7 @@ async fn test_execute() -> Result<()> {
             &[&1i32, &2i32, &3i32],
         )
         .await?
-        .total()
-        .await?;
+        .total();
 
     assert_eq!(3, insert_count);
 
@@ -152,16 +151,14 @@ async fn test_execute() -> Result<()> {
             &[&2i32, &1i32],
         )
         .await?
-        .total()
-        .await?;
+        .total();
 
     assert_eq!(1, update_count);
 
     let delete_count = conn
         .execute("DELETE ##TestExecute WHERE id <> @P1", &[&3i32])
         .await?
-        .total()
-        .await?;
+        .total();
 
     assert_eq!(2, delete_count);
 
@@ -182,7 +179,7 @@ async fn test_execute_multiple_separate_results() -> Result<()> {
         )
         .await?;
 
-    let result: Vec<_> = insert_count.try_collect().await?;
+    let result: Vec<_> = insert_count.into_iter().collect();
     assert_eq!(vec![1, 2], result);
 
     Ok(())
@@ -202,7 +199,7 @@ async fn test_execute_multiple_total() -> Result<()> {
         )
         .await?;
 
-    let result = insert_count.total().await?;
+    let result = insert_count.total();
     assert_eq!(3, result);
 
     Ok(())
@@ -634,8 +631,7 @@ async fn test_varbinary_empty() -> Result<()> {
             &[&Option::<Vec<u8>>::None],
         )
         .await?
-        .total()
-        .await?;
+        .total();
 
     assert_eq!(1, total);
 
@@ -671,8 +667,7 @@ async fn test_binary() -> Result<()> {
             &[&binary.as_slice()],
         )
         .await?
-        .total()
-        .await?;
+        .total();
 
     assert_eq!(1, inserted);
 
@@ -706,8 +701,7 @@ async fn test_var_binary() -> Result<()> {
             &[&binary.as_slice()],
         )
         .await?
-        .total()
-        .await?;
+        .total();
 
     assert_eq!(1, inserted);
 
@@ -755,8 +749,7 @@ async fn test_max_binary() -> Result<()> {
             &[&binary.as_slice()],
         )
         .await?
-        .total()
-        .await?;
+        .total();
 
     assert_eq!(1, inserted);
 
@@ -787,8 +780,7 @@ async fn test_naive_small_date_time_tds73() -> Result<()> {
 
     conn.execute("INSERT INTO ##TestSmallDt (date) VALUES (@P1)", &[&dt])
         .await?
-        .total()
-        .await?;
+        .total();
 
     let stream = conn.query("SELECT date FROM ##TestSmallDt", &[]).await?;
 
@@ -814,8 +806,7 @@ async fn test_naive_date_time2_tds73() -> Result<()> {
 
     conn.execute("INSERT INTO ##NaiveDateTime2 (date) VALUES (@P1)", &[&dt])
         .await?
-        .total()
-        .await?;
+        .total();
 
     let stream = conn.query("SELECT date FROM ##NaiveDateTime2", &[]).await?;
 


### PR DESCRIPTION
I've had a go at the task:  Execute doesn't really need to be a stream, The results should be collected to a vector for better error handling and provided as an iterator or using the total method.

Please let me know if there are any issues with the way it is anything that needs fixing 

Also, would it make sense for `ExecResult` to have a `Vec<Result<u64>>` which could potentially show which query failed?