### PR TITLE
Exec result v2

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -136,14 +136,14 @@ impl Client {
         &'a mut self,
         query: impl Into<Cow<'_, str>>,
         params: &'b [&'b dyn ToSql],
-    ) -> crate::Result<ExecuteResult<'a>> {
+    ) -> crate::Result<ExecuteResult> {
         self.connection.flush_stream().await?;
         let rpc_params = Self::rpc_params(query);
 
         self.rpc_perform_query(RpcProcId::SpExecuteSQL, rpc_params, params)
             .await?;
 
-        Ok(ExecuteResult::new(&mut self.connection))
+        Ok(ExecuteResult::try_new(&mut self.connection).await?)
     }
 
     /// Executes SQL statements in the SQL Server, returning resulting rows.

--- a/src/client.rs
+++ b/src/client.rs
@@ -186,7 +186,6 @@ impl Client {
             .await?;
 
         let ts = TokenStream::new(&mut self.connection);
-        //let mut stream = std::pin::Pin::new(&mut ts);
         let mut result = QueryResult::new(ts.try_unfold());
 
         result.fetch_metadata().await?;

--- a/src/client.rs
+++ b/src/client.rs
@@ -186,6 +186,7 @@ impl Client {
             .await?;
 
         let ts = TokenStream::new(&mut self.connection);
+        //let mut stream = std::pin::Pin::new(&mut ts);
         let mut result = QueryResult::new(ts.try_unfold());
 
         result.fetch_metadata().await?;

--- a/src/client.rs
+++ b/src/client.rs
@@ -143,7 +143,7 @@ impl Client {
         self.rpc_perform_query(RpcProcId::SpExecuteSQL, rpc_params, params)
             .await?;
 
-        Ok(ExecuteResult::try_new(&mut self.connection).await?)
+        Ok(ExecuteResult::new(&mut self.connection).await?)
     }
 
     /// Executes SQL statements in the SQL Server, returning resulting rows.

--- a/src/tds/stream/prepared.rs
+++ b/src/tds/stream/prepared.rs
@@ -1,6 +1,7 @@
 use super::ReceivedToken;
 use crate::tds::codec::DoneStatus;
 use futures::{ready, Stream};
+use futures_util::StreamExt;
 use std::{
     pin::Pin,
     task::{self, Poll},
@@ -30,10 +31,7 @@ impl<'a> Stream for PreparedStream<'a> {
                 return Poll::Ready(Some(Ok(this.read_ahead.take().unwrap())));
             }
 
-            use futures_util::StreamExt;
-            //let mut stream = unsafe { Pin::new_unchecked(&mut self.token_stream) };
             let stream = &mut this.token_stream;
-            //let mut stream = Pin::new(&mut *self.get_mut().token_stream);
             let item = match ready!(stream.poll_next_unpin(cx)) {
                 Some(res) => res?,
                 None => return Poll::Ready(None),

--- a/src/tds/stream/query.rs
+++ b/src/tds/stream/query.rs
@@ -27,7 +27,7 @@ pub struct QueryStream<'a> {
 
 impl<'a> QueryStream<'a> {
     pub(crate) fn new(
-        token_stream: Box<dyn Stream<Item = crate::Result<ReceivedToken>> + 'a>,
+        token_stream: Pin<Box<dyn Stream<Item = crate::Result<ReceivedToken>> + 'a>>,
     ) -> Self {
         let prepared_stream = PreparedStream::new(token_stream);
 

--- a/src/tds/stream/token.rs
+++ b/src/tds/stream/token.rs
@@ -1,5 +1,4 @@
-#[cfg(windows)]
-use crate::tds::codec::TokenSSPI;
+#[cfg(windows)] use crate::tds::codec::TokenSSPI;
 use crate::{
     client::Connection,
     tds::codec::{
@@ -45,7 +44,7 @@ impl<'a> TokenStream<'a> {
 
     pub(crate) async fn flush_done(self) -> crate::Result<TokenDone> {
         let mut stream = self.try_unfold();
-        let mut stream = unsafe { Pin::new_unchecked(&mut *stream) };
+        //let mut stream = unsafe { Pin::new_unchecked(&mut *stream) };
 
         loop {
             match stream.try_next().await? {
@@ -59,7 +58,7 @@ impl<'a> TokenStream<'a> {
     #[cfg(windows)]
     pub(crate) async fn flush_sspi(self) -> crate::Result<TokenSSPI> {
         let mut stream = self.try_unfold();
-        let mut stream = unsafe { Pin::new_unchecked(&mut *stream) };
+        //let mut stream = unsafe { Pin::new_unchecked(&mut *stream) };
 
         loop {
             match stream.try_next().await? {
@@ -168,7 +167,7 @@ impl<'a> TokenStream<'a> {
         Ok(ReceivedToken::SSPI(sspi))
     }
 
-    pub fn try_unfold(self) -> Box<dyn Stream<Item = crate::Result<ReceivedToken>> + 'a> {
+    pub fn try_unfold(self) -> Pin<Box<dyn Stream<Item = crate::Result<ReceivedToken>> + 'a>> {
         let s = futures::stream::try_unfold(self, |mut this| async move {
             if this.conn.is_eof() {
                 return Ok(None);
@@ -201,6 +200,6 @@ impl<'a> TokenStream<'a> {
             Ok(Some((token, this)))
         });
 
-        Box::new(s)
+        Box::pin(s)
     }
 }

--- a/src/tds/stream/token.rs
+++ b/src/tds/stream/token.rs
@@ -44,7 +44,6 @@ impl<'a> TokenStream<'a> {
 
     pub(crate) async fn flush_done(self) -> crate::Result<TokenDone> {
         let mut stream = self.try_unfold();
-        //let mut stream = unsafe { Pin::new_unchecked(&mut *stream) };
 
         loop {
             match stream.try_next().await? {
@@ -58,7 +57,6 @@ impl<'a> TokenStream<'a> {
     #[cfg(windows)]
     pub(crate) async fn flush_sspi(self) -> crate::Result<TokenSSPI> {
         let mut stream = self.try_unfold();
-        //let mut stream = unsafe { Pin::new_unchecked(&mut *stream) };
 
         loop {
             match stream.try_next().await? {

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -56,7 +56,7 @@ async fn test_kanji_varchars() -> Result<()> {
         )
         .await?;
 
-    assert_eq!(2, res.total().await?);
+    assert_eq!(2, res.total());
 
     let stream = conn.query("SELECT content FROM ##TestKanji", &[]).await?;
 
@@ -86,7 +86,7 @@ async fn test_finnish_varchars() -> Result<()> {
         )
         .await?;
 
-    assert_eq!(1, res.total().await?);
+    assert_eq!(1, res.total());
 
     let stream = conn.query("SELECT content FROM ##TestFinnish", &[]).await?;
 
@@ -113,8 +113,7 @@ async fn test_execute() -> Result<()> {
             &[&1i32, &2i32, &3i32],
         )
         .await?
-        .total()
-        .await?;
+        .total();
 
     assert_eq!(3, insert_count);
 
@@ -124,16 +123,14 @@ async fn test_execute() -> Result<()> {
             &[&2i32, &1i32],
         )
         .await?
-        .total()
-        .await?;
+        .total();
 
     assert_eq!(1, update_count);
 
     let delete_count = conn
         .execute("DELETE ##TestExecute WHERE id <> @P1", &[&3i32])
         .await?
-        .total()
-        .await?;
+        .total();
 
     assert_eq!(2, delete_count);
 
@@ -154,7 +151,7 @@ async fn test_execute_multiple_separate_results() -> Result<()> {
         )
         .await?;
 
-    let result: Vec<_> = insert_count.try_collect().await?;
+    let result: Vec<_> = insert_count.into_iter().collect();
     assert_eq!(vec![1, 2], result);
 
     Ok(())
@@ -174,7 +171,7 @@ async fn test_execute_multiple_total() -> Result<()> {
         )
         .await?;
 
-    let result = insert_count.total().await?;
+    let result = insert_count.total();
     assert_eq!(3, result);
 
     Ok(())
@@ -606,8 +603,7 @@ async fn test_varbinary_empty() -> Result<()> {
             &[&Option::<Vec<u8>>::None],
         )
         .await?
-        .total()
-        .await?;
+        .total();
 
     assert_eq!(1, total);
 
@@ -643,8 +639,7 @@ async fn test_binary() -> Result<()> {
             &[&binary.as_slice()],
         )
         .await?
-        .total()
-        .await?;
+        .total();
 
     assert_eq!(1, inserted);
 
@@ -678,8 +673,7 @@ async fn test_var_binary() -> Result<()> {
             &[&binary.as_slice()],
         )
         .await?
-        .total()
-        .await?;
+        .total();
 
     assert_eq!(1, inserted);
 
@@ -727,8 +721,7 @@ async fn test_max_binary() -> Result<()> {
             &[&binary.as_slice()],
         )
         .await?
-        .total()
-        .await?;
+        .total();
 
     assert_eq!(1, inserted);
 
@@ -759,8 +752,7 @@ async fn test_naive_small_date_time_tds73() -> Result<()> {
 
     conn.execute("INSERT INTO ##TestSmallDt (date) VALUES (@P1)", &[&dt])
         .await?
-        .total()
-        .await?;
+        .total();
 
     let stream = conn.query("SELECT date FROM ##TestSmallDt", &[]).await?;
 
@@ -786,8 +778,7 @@ async fn test_naive_date_time2_tds73() -> Result<()> {
 
     conn.execute("INSERT INTO ##NaiveDateTime2 (date) VALUES (@P1)", &[&dt])
         .await?
-        .total()
-        .await?;
+        .total();
 
     let stream = conn.query("SELECT date FROM ##NaiveDateTime2", &[]).await?;
 


### PR DESCRIPTION
I've created a new pull request and will close the old one (This one has a proper rebase :D)

Changes here:
* `ExecResult` now stores a `Vec<u64>`
* Avoided the unsafe in `ExecResult::new` in the previous PR by using the same tactic as in query.rs (` let this = self.get_mut();` and then `poll_next_unpin` for `TokenStream`'s `impl Stream`)