### PR TITLE
Fix Windows issues with integrated login for certain encryption modes

### DIFF
--- a/examples/new.rs
+++ b/examples/new.rs
@@ -5,7 +5,7 @@ use tiberius::{AuthMethod, Client};
 async fn main() -> anyhow::Result<()> {
     env_logger::init();
     let mut builder = Client::builder();
-    builder.host("0.0.0.0");
+    builder.host("localhost");
     builder.port(1433);
     builder.database("master");
     builder.authentication(AuthMethod::sql_server("SA", "<YourStrong@Passw0rd>"));

--- a/src/client/connection.rs
+++ b/src/client/connection.rs
@@ -327,7 +327,7 @@ impl Connection {
 
     /// Performs needed handshakes for Windows-based authentications.
     #[cfg(windows)]
-    fn windows_auth<'a>(
+    async fn windows_auth<'a>(
         &'a mut self,
         mut msg: LoginMessage<'a>,
         mut client: impl NextBytes,

--- a/src/tds/codec/token/token_sspi.rs
+++ b/src/tds/codec/token/token_sspi.rs
@@ -1,4 +1,4 @@
-use crate::{async_read_le_ext::AsyncReadLeExt, protocol::codec::Encode};
+use crate::{tds::codec::Encode, sql_read_bytes::SqlReadBytes};
 use bytes::BytesMut;
 use tokio::io::AsyncReadExt;
 
@@ -18,7 +18,7 @@ impl TokenSSPI {
 
     pub(crate) async fn decode_async<R>(src: &mut R) -> crate::Result<Self>
     where
-        R: AsyncReadLeExt + Unpin,
+        R: SqlReadBytes + Unpin,
     {
         let len = src.read_u16_le().await? as usize;
         let mut bytes = vec![0; len];

--- a/src/tds/stream/token.rs
+++ b/src/tds/stream/token.rs
@@ -161,7 +161,7 @@ impl<'a> TokenStream<'a> {
     #[cfg(windows)]
     async fn get_sspi(&mut self) -> crate::Result<ReceivedToken> {
         let sspi = TokenSSPI::decode_async(self.conn).await?;
-        event!(Level::INFO, "SSPI response");
+        event!(Level::TRACE, "SSPI response");
         Ok(ReceivedToken::SSPI(sspi))
     }
 


### PR DESCRIPTION
This will fix compilation errors, but now it seems `EncryptionMode::Off` is just stalling if using Windows auth. Really need to get the AppVeyor tests working soon to catch these.