### PR TITLE
QueryResult should return columns as &[Column]

### DIFF
--- a/src/result.rs
+++ b/src/result.rs
@@ -5,7 +5,7 @@ use crate::{
         codec::DoneStatus,
         stream::{QueryStream, QueryStreamState, ReceivedToken, TokenStream},
     },
-    Row,
+    Column, Row,
 };
 use futures::{Stream, StreamExt, TryStreamExt};
 use std::{fmt::Debug, pin::Pin, task};
@@ -109,13 +109,13 @@ impl<'a> QueryResult<'a> {
     ///     )
     ///     .await?;
     ///
-    /// assert_eq!(vec!["foo"], result_set.columns());
+    /// assert_eq!("foo", result_set.columns()[0].name());
     /// result_set.next_resultset();
-    /// assert_eq!(vec!["bar"], result_set.columns());
+    /// assert_eq!("bar", result_set.columns()[0].name());
     /// # Ok(())
     /// # }
     /// ```
-    pub fn columns(&'a self) -> Vec<&str> {
+    pub fn columns(&'a self) -> &[Column] {
         self.stream.columns()
     }
 

--- a/src/tds/stream/query.rs
+++ b/src/tds/stream/query.rs
@@ -75,22 +75,10 @@ impl<'a> QueryStream<'a> {
         }
     }
 
-    pub(crate) fn columns(&self) -> Vec<&str> {
+    pub(crate) fn columns(&self) -> &[Column] {
         match self.state {
-            QueryStreamState::HasNext => self
-                .previous_columns
-                .as_ref()
-                .unwrap()
-                .iter()
-                .map(|c| c.name.as_str())
-                .collect(),
-            _ => self
-                .current_columns
-                .as_ref()
-                .unwrap()
-                .iter()
-                .map(|c| c.name.as_str())
-                .collect(),
+            QueryStreamState::HasNext => &self.previous_columns.as_ref().unwrap(),
+            _ => &self.current_columns.as_ref().unwrap(),
         }
     }
 

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -255,22 +255,22 @@ async fn multiple_queries() -> Result<()> {
         .query("SELECT 'a' AS first; SELECT 'b' AS second;", &[])
         .await?;
 
-    assert_eq!(vec!["first"], stream.columns());
+    assert_eq!("first", stream.columns()[0].name());
 
     while let Some(x) = stream.by_ref().try_next().await? {
         assert_eq!(Some("a"), x.get(0))
     }
 
-    assert_eq!(vec!["first"], stream.columns());
+    assert_eq!("first", stream.columns()[0].name());
 
     assert!(stream.next_resultset());
-    assert_eq!(stream.columns(), vec!["second"]);
+    assert_eq!("second", stream.columns()[0].name());
 
     while let Some(x) = stream.by_ref().try_next().await? {
         assert_eq!(Some("b"), x.get(0))
     }
 
-    assert_eq!(vec!["second"], stream.columns());
+    assert_eq!("second", stream.columns()[0].name());
 
     Ok(())
 }


### PR DESCRIPTION
The `QueryResult` mapped column names only, we should return the actual column struct for being comparable with the API in `Row`.