### PR TITLE
A way to execute simple queries

### DIFF
--- a/src/result.rs
+++ b/src/result.rs
@@ -21,6 +21,8 @@ use task::Poll;
 /// `true` is needed. When the [`next_resultset`] returns `false` the results
 /// should not be polled anymore.
 ///
+/// # Example
+///
 /// ```
 /// # use tiberius::ClientBuilder;
 /// # use std::env;
@@ -89,6 +91,8 @@ impl<'a> QueryResult<'a> {
     /// Names of the columns of the current resultset. Order is the same as the
     /// order of columns in the rows. Needs to be called separately for every
     /// result set.
+    ///
+    /// # Example
     ///
     /// ```no_run
     /// # use tiberius::ClientBuilder;
@@ -185,6 +189,8 @@ impl<'a> Stream for QueryResult<'a> {
 /// If executing multiple queries, the resulting counts will be come separately,
 /// marking the rows affected for each query.
 ///
+/// # Example
+///
 /// ```no_run
 /// # use tiberius::ClientBuilder;
 /// # use std::env;
@@ -236,6 +242,8 @@ impl<'a> ExecuteResult {
     }
 
     /// Aggregates all resulting row counts into a sum.
+    ///
+    /// # Example
     ///
     /// ```no_run
     /// # use tiberius::ClientBuilder;

--- a/src/row.rs
+++ b/src/row.rs
@@ -254,6 +254,8 @@ impl Row {
     /// Columns defining the row data. Columns listed here are in the same order
     /// as the resulting data.
     ///
+    /// # Example
+    ///
     /// ```
     /// # use tiberius::ClientBuilder;
     /// # use std::env;
@@ -281,6 +283,8 @@ impl Row {
 
     /// Returns the number of columns in the row.
     ///
+    /// # Example
+    ///
     /// ```
     /// # use tiberius::ClientBuilder;
     /// # use std::env;
@@ -307,6 +311,8 @@ impl Row {
 
     /// Retrieve a column value for a given column index, which can either be
     /// the zero-indexed position or the name of the column.
+    ///
+    /// # Example
     ///
     /// ```
     /// # use tiberius::ClientBuilder;

--- a/src/tds/codec.rs
+++ b/src/tds/codec.rs
@@ -1,3 +1,4 @@
+mod batch_request;
 mod column_data;
 mod decode;
 mod encode;
@@ -10,6 +11,7 @@ mod token;
 mod type_info;
 
 use crate::SqlReadBytes;
+pub use batch_request::*;
 use bytes::BytesMut;
 pub use column_data::*;
 pub use decode::*;

--- a/src/tds/codec/batch_request.rs
+++ b/src/tds/codec/batch_request.rs
@@ -1,0 +1,23 @@
+use super::{AllHeaderTy, Encode, ALL_HEADERS_LEN_TX};
+use bytes::{BufMut, BytesMut};
+use std::borrow::Cow;
+
+pub struct BatchRequest<'a> {
+    pub(crate) queries: Cow<'a, str>,
+}
+
+impl<'a> Encode<BytesMut> for BatchRequest<'a> {
+    fn encode(self, dst: &mut BytesMut) -> crate::Result<()> {
+        dst.put_u32_le(ALL_HEADERS_LEN_TX as u32);
+        dst.put_u32_le(ALL_HEADERS_LEN_TX as u32 - 4);
+        dst.put_u16_le(AllHeaderTy::TransactionDescriptor as u16);
+        dst.put_u64_le(0u64);
+        dst.put_u32_le(1);
+
+        for c in self.queries.encode_utf16() {
+            dst.put_u16_le(c);
+        }
+
+        Ok(())
+    }
+}

--- a/src/tds/codec/header.rs
+++ b/src/tds/codec/header.rs
@@ -92,6 +92,14 @@ impl PacketHeader {
         }
     }
 
+    pub fn batch(ctx: &Context) -> Self {
+        Self {
+            ty: PacketType::SQLBatch,
+            status: PacketStatus::NormalMessage,
+            ..ctx.new_header(0)
+        }
+    }
+
     pub fn set_status(&mut self, status: PacketStatus) {
         self.status = status;
     }

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -22,6 +22,16 @@ async fn connect() -> Result<Client> {
     builder.build().await
 }
 
+#[tokio::test]
+async fn test_simple_query() -> Result<()> {
+    let mut conn = connect().await?;
+    let row = conn.simple_query("SELECT 1").await?.into_row().await?;
+
+    assert_eq!(Some(1i32), row.get(0));
+
+    Ok(())
+}
+
 #[cfg(feature = "tls")]
 #[tokio::test]
 async fn connect_with_full_encryption() -> Result<()> {


### PR DESCRIPTION
This will skip preparing a statement, which is useful for certain queries that cannot be executed as statements.