### PR TITLE
Fixing `tinyint` encode/decode

### DIFF
--- a/src/from_sql.rs
+++ b/src/from_sql.rs
@@ -9,7 +9,7 @@ use uuid::Uuid;
 ///
 /// |Rust type|Server type|
 /// |--------|--------|
-/// |`i8`|`tinyint`|
+/// |`u8`|`tinyint`|
 /// |`i16`|`smallint`|
 /// |`i32`|`int`|
 /// |`i64`|`bigint`|
@@ -58,7 +58,7 @@ where
 }
 
 from_sql!(bool: ColumnData::Bit(val) => (*val, val));
-from_sql!(i8: ColumnData::I8(val) => (*val, val));
+from_sql!(u8: ColumnData::U8(val) => (*val, val));
 from_sql!(i16: ColumnData::I16(val) => (*val, val));
 from_sql!(i32: ColumnData::I32(val) => (*val, val));
 from_sql!(i64: ColumnData::I64(val) => (*val, val));

--- a/src/tds/codec/token/token_col_metadata.rs
+++ b/src/tds/codec/token/token_col_metadata.rs
@@ -26,7 +26,7 @@ impl BaseMetaDataColumn {
         match self.ty {
             TypeInfo::FixedLen(ty) => match ty {
                 FixedLenType::Null => ColumnData::I32(None),
-                FixedLenType::Int1 => ColumnData::I8(None),
+                FixedLenType::Int1 => ColumnData::U8(None),
                 FixedLenType::Bit => ColumnData::Bit(None),
                 FixedLenType::Int2 => ColumnData::I16(None),
                 FixedLenType::Int4 => ColumnData::I32(None),

--- a/src/to_sql.rs
+++ b/src/to_sql.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 ///
 /// |Rust type|Server type|
 /// |--------|--------|
-/// |`i8`|`tinyint`|
+/// |`u8`|`tinyint`|
 /// |`i16`|`smallint`|
 /// |`i32`|`int`|
 /// |`i64`|`bigint`|
@@ -76,7 +76,7 @@ into_sql!(self_,
 
 to_sql!(self_,
         bool: (ColumnData::Bit, *self_);
-        i8: (ColumnData::I8, *self_);
+        u8: (ColumnData::U8, *self_);
         i16: (ColumnData::I16, *self_);
         i32: (ColumnData::I32, *self_);
         i64: (ColumnData::I64, *self_);

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -383,17 +383,17 @@ where
 }
 
 #[test_on_runtimes]
-async fn i8_token<S>(mut conn: tiberius::Client<S>) -> Result<()>
+async fn u8_token<S>(mut conn: tiberius::Client<S>) -> Result<()>
 where
     S: AsyncRead + AsyncWrite + Unpin + Send,
 {
     let row = conn
-        .query("SELECT @P1", &[&-4i8])
+        .query("SELECT @P1", &[&4u8])
         .await?
         .into_row()
         .await?
         .unwrap();
-    assert_eq!(Some(-4i8), row.get(0));
+    assert_eq!(Some(4u8), row.get(0));
     Ok(())
 }
 


### PR DESCRIPTION
It was mistakenly handled as `i8`, even though the documentation says it's from 0 to 255, meaning `u8`.