### PR TITLE
make packet_id wrapping explicit

### DIFF
--- a/src/tds/context.rs
+++ b/src/tds/context.rs
@@ -28,7 +28,7 @@ impl Context {
 
     pub fn next_packet_id(&mut self) -> u8 {
         let id = self.packet_id;
-        self.packet_id += 1;
+        self.packet_id = self.packet_id.wrapping_add(1);
         id
     }
 

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -69,6 +69,30 @@ where
 }
 
 #[test_on_runtimes]
+async fn transactions_300<S>(mut conn: tiberius::Client<S>) -> Result<()>
+where
+    S: AsyncRead + AsyncWrite + Unpin + Send,
+{
+    for _ in 1..300 {
+
+        conn.simple_query("BEGIN TRAN").await?;
+
+        let row = conn
+            .query("SELECT @P1", &[&-4i32])
+            .await?
+            .into_row()
+            .await?
+            .unwrap();
+
+        assert_eq!(Some(-4i32), row.get(0));
+
+        conn.simple_query("COMMIT").await?;
+    }
+
+    Ok(())
+}
+
+#[test_on_runtimes]
 async fn multistatement_query_with_exec_proc<S>(mut conn: tiberius::Client<S>) -> Result<()>
 where
     S: AsyncRead + AsyncWrite + Unpin + Send,


### PR DESCRIPTION
closes #68 

* This makes the desired wrapping behavior explicit 
* This potentially causes a very small performance cost - an alternative would be to document that doing many queries in debug builds can cause a panic