### PR TITLE
Use GSSAPI for IntegratedSecurity on Unix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,10 +46,10 @@ futures-sink = "0.3"
 async-trait = "0.1"
 
 [target.'cfg(windows)'.dependencies]
-winauth = "0.0.4"
+winauth = { version = "0.0.4", optional = true }
 
 [target.'cfg(unix)'.dependencies]
-libgssapi = "0.4"
+libgssapi = { version = "0.4", optional = true }
 
 [dependencies.tokio]
 version = "0.2"
@@ -113,11 +113,12 @@ anyhow = "1"
 env_logger = "0.7"
 
 [package.metadata.docs.rs]
-features = ["tls", "chrono", "tds73", "sql-browser-async-std", "sql-browser-tokio"]
+features = ["tls", "chrono", "tds73", "sql-browser-async-std", "sql-browser-tokio", "integrated-auth"]
 
 [features]
-default = ["tls", "tds73"]
+default = ["tls", "tds73", "integrated-auth"]
 tls = ["async-native-tls"]
 tds73 = []
 sql-browser-async-std = ["async-std"]
 sql-browser-tokio = ["tokio", "tokio-util"]
+integrated-auth = ["winauth", "libgssapi"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,9 @@ async-trait = "0.1"
 [target.'cfg(windows)'.dependencies]
 winauth = "0.0.4"
 
+[target.'cfg(unix)'.dependencies]
+libgssapi = "0.4"
+
 [dependencies.tokio]
 version = "0.2"
 optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ futures-sink = "0.3"
 async-trait = "0.1"
 
 [target.'cfg(windows)'.dependencies]
-winauth = { version = "0.0.4", optional = true }
+winauth = "0.0.4"
 
 [target.'cfg(unix)'.dependencies]
 libgssapi = { version = "0.4", optional = true }
@@ -113,12 +113,12 @@ anyhow = "1"
 env_logger = "0.7"
 
 [package.metadata.docs.rs]
-features = ["tls", "chrono", "tds73", "sql-browser-async-std", "sql-browser-tokio", "integrated-auth"]
+features = ["tls", "chrono", "tds73", "sql-browser-async-std", "sql-browser-tokio", "integrated-auth-gssapi"]
 
 [features]
-default = ["tls", "tds73", "integrated-auth"]
+default = ["tls", "tds73"]
 tls = ["async-native-tls"]
 tds73 = []
 sql-browser-async-std = ["async-std"]
 sql-browser-tokio = ["tokio", "tokio-util"]
-integrated-auth = ["winauth", "libgssapi"]
+integrated-auth-gssapi = ["libgssapi"]

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ things:
 | `rust_decimal` | Read and write `numeric`/`decimal` values using `rust_decimal`'s `Decimal`.           | `disabled` |
 | `sql-browser-async-std` | SQL Browser implementation for the `TcpStream` of async-std.                  | `disabled` |
 | `sql-browser-tokio`     | SQL Browser implementation for the `TcpStream` of Tokio.                      | `disabled` |
+| `integrated-auth-gssapi`     | Support for using Integrated Auth via GSSAPI                            | `disabled` |
 
 ### Supported protocols
 
@@ -76,6 +77,17 @@ tiberius = { version = "0.X", default-features=false, features=["chrono"] }
 ```
 
 **This will disable encryption for your ENTIRE crate**  
+
+### Integrated Authentication (TrustedConnection) on \*nix
+
+With the `integrated-auth-gssapi` feature enabled, the crate requires the GSSAPI/Kerberos libraries/headers installed:
+  * [CentOS](https://pkgs.org/download/krb5-devel)
+  * [Arch](https://www.archlinux.org/packages/core/x86_64/krb5/)
+  * [Debian](https://tracker.debian.org/pkg/krb5) (you need the -dev packages to build)
+  * [Ubuntu](https://packages.ubuntu.com/bionic-updates/libkrb5-dev)
+  * [Mac - Homebrew](https://formulae.brew.sh/formula/krb5)
+
+Additionally, your runtime system will need to be trusted by and configured for the Active Directory domain your SQL Server is part of. In particular, you'll need to be able to get a valid TGT for your identity, via `kinit` or a keytab. This setup varies by environment and OS, but your friendly network/system administrator should be able to help figure out the specifics.
 
 ## Security
 

--- a/src/client/auth.rs
+++ b/src/client/auth.rs
@@ -59,7 +59,7 @@ pub enum AuthMethod {
     /// platforms.
     WindowsIntegrated,
     #[cfg(any(unix, doc))]
-    /// Authenticate as the currently logged in user. Only available on Unix platforms.
+    /// Authenticate as the currently logged in (Kerberos) user. Only available on Unix platforms.
     Integrated,
     #[doc(hidden)]
     None,

--- a/src/client/auth.rs
+++ b/src/client/auth.rs
@@ -58,6 +58,9 @@ pub enum AuthMethod {
     /// Authenticate as the currently logged in user. Only available on Windows
     /// platforms.
     WindowsIntegrated,
+    #[cfg(any(unix, doc))]
+    /// Authenticate as the currently logged in user. Only available on Unix platforms.
+    Integrated,
     #[doc(hidden)]
     None,
 }

--- a/src/client/auth.rs
+++ b/src/client/auth.rs
@@ -58,8 +58,9 @@ pub enum AuthMethod {
     /// Authenticate as the currently logged in user. Only available on Windows
     /// platforms.
     WindowsIntegrated,
-    #[cfg(any(unix, doc))]
-    /// Authenticate as the currently logged in (Kerberos) user. Only available on Unix platforms.
+    #[cfg(any(feature = "integrated-auth-gssapi", doc))]
+    /// Authenticate as the currently logged in (Kerberos) user. (Enable feature
+    /// `integrated-auth-gssapi`) to enable.
     Integrated,
     #[doc(hidden)]
     None,

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -132,7 +132,7 @@ impl Config {
     /// |Parameter|Allowed values|Description|
     /// |--------|--------|--------|
     /// |`server`|`<string>`|The name or network address of the instance of SQL Server to which to connect. The port number can be specified after the server name. The correct form of this parameter is either `tcp:host,port` or `tcp:host\\instance`|
-    /// |`IntegratedSecurity`|`true`,`false`,`yes`,`no`|Toggle between Windows authentication and SQL authentication.|
+    /// |`IntegratedSecurity`|`true`,`false`,`yes`,`no`|Toggle between Windows/Kerberos authentication and SQL authentication.|
     /// |`uid`,`username`,`user`,`user id`|`<string>`|The SQL Server login account.|
     /// |`password`,`pwd`|`<string>`|The password for the SQL Server account logging on.|
     /// |`database`|`<string>`|The name of the database.|
@@ -281,6 +281,8 @@ impl AdoNetString {
                 (None, None) => Ok(AuthMethod::WindowsIntegrated),
                 _ => Ok(AuthMethod::windows(user.unwrap_or(""), pw.unwrap_or(""))),
             },
+            #[cfg(unix)]
+            Some(val) if val.to_lowercase() == "sspi" || Self::parse_bool(val)? => Ok(AuthMethod::Integrated),
             _ => Ok(AuthMethod::sql_server(user.unwrap_or(""), pw.unwrap_or(""))),
         }
     }

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -281,7 +281,7 @@ impl AdoNetString {
                 (None, None) => Ok(AuthMethod::WindowsIntegrated),
                 _ => Ok(AuthMethod::windows(user.unwrap_or(""), pw.unwrap_or(""))),
             },
-            #[cfg(unix)]
+            #[cfg(feature = "integrated-auth-gssapi")]
             Some(val) if val.to_lowercase() == "sspi" || Self::parse_bool(val)? => Ok(AuthMethod::Integrated),
             _ => Ok(AuthMethod::sql_server(user.unwrap_or(""), pw.unwrap_or(""))),
         }

--- a/src/client/connection.rs
+++ b/src/client/connection.rs
@@ -293,9 +293,11 @@ where {
 
                 let next_token = match ctx.step(Some(auth_bytes.as_ref()))? {
                     Some(response) => {
+                        event!(Level::TRACE, response_len = response.len());
                         TokenSSPI::new(Vec::from(response.deref()))
                     },
                     None => {
+                        event!(Level::TRACE, response_len = 0);
                         TokenSSPI::new(Vec::new())
                     }
                 };

--- a/src/error.rs
+++ b/src/error.rs
@@ -40,6 +40,10 @@ pub enum Error {
     #[error("Error forming TLS connection: {}", _0)]
     /// An error in the TLS handshake.
     Tls(String),
+    #[cfg(any(unix, doc))]
+    /// An error from the GSSAPI library.
+    #[error("GSSAPI Error: {}", _0)]
+    Gssapi(String)
 }
 
 impl From<uuid::Error> for Error {
@@ -91,5 +95,12 @@ impl From<std::string::FromUtf8Error> for Error {
 impl From<std::string::FromUtf16Error> for Error {
     fn from(_err: std::string::FromUtf16Error) -> Error {
         Error::Utf16
+    }
+}
+
+#[cfg(unix)]
+impl From<libgssapi::error::Error> for Error {
+    fn from(err: libgssapi::error::Error) -> Error {
+        Error::Gssapi(format!("{}", err))
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -40,7 +40,7 @@ pub enum Error {
     #[error("Error forming TLS connection: {}", _0)]
     /// An error in the TLS handshake.
     Tls(String),
-    #[cfg(any(unix, doc))]
+    #[cfg(any(feature = "integrated-auth-gssapi", doc))]
     /// An error from the GSSAPI library.
     #[error("GSSAPI Error: {}", _0)]
     Gssapi(String)
@@ -98,7 +98,7 @@ impl From<std::string::FromUtf16Error> for Error {
     }
 }
 
-#[cfg(unix)]
+#[cfg(feature = "integrated-auth-gssapi")]
 impl From<libgssapi::error::Error> for Error {
     fn from(err: libgssapi::error::Error) -> Error {
         Error::Gssapi(format!("{}", err))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,8 @@
 //! authenticate the user.
 //! - Authentication with Windows credentials
 //! - Authentication with currently logged in Windows user / Kerberos credentials
+//! - Authentication with currently logged in Kerberos credentials via GSSAPI (feature =
+//! `integrated-auth-gssapi`)
 //!
 //! # TLS
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,10 +92,9 @@
 //! Tiberius supports different [ways of authentication] to the SQL Server:
 //!
 //! - SQL Server authentication uses the facilities of the database to
-//! authenticate the user. This is also the only cross-platform method that
-//! works outside of Windows platforms.
+//! authenticate the user.
 //! - Authentication with Windows credentials
-//! - Authentication with currently logged in Windows user
+//! - Authentication with currently logged in Windows user / Kerberos credentials
 //!
 //! # TLS
 //!

--- a/src/tds/codec/token.rs
+++ b/src/tds/codec/token.rs
@@ -7,7 +7,6 @@ mod token_login_ack;
 mod token_order;
 mod token_return_value;
 mod token_row;
-#[cfg(windows)]
 mod token_sspi;
 mod token_type;
 
@@ -20,6 +19,5 @@ pub use token_login_ack::*;
 pub use token_order::*;
 pub use token_return_value::*;
 pub use token_row::*;
-#[cfg(windows)]
 pub use token_sspi::*;
 pub use token_type::*;

--- a/src/tds/codec/token/token_sspi.rs
+++ b/src/tds/codec/token/token_sspi.rs
@@ -12,6 +12,7 @@ impl AsRef<[u8]> for TokenSSPI {
 }
 
 impl TokenSSPI {
+    #[cfg(any(windows, feature = "integrated-auth-gssapi"))]
     pub fn new(bytes: Vec<u8>) -> Self {
         Self(bytes)
     }

--- a/src/tds/context.rs
+++ b/src/tds/context.rs
@@ -62,6 +62,7 @@ impl Context {
         self.spn = Some(format!("MSSQLSvc/{}:{}", host.as_ref(), port));
     }
 
+    #[cfg(any(windows, feature = "integrated-auth-gssapi"))]
     pub fn spn(&self) -> &str {
         self.spn.as_ref().map(|s| s.as_str()).unwrap_or("")
     }

--- a/src/tds/context.rs
+++ b/src/tds/context.rs
@@ -9,7 +9,6 @@ pub(crate) struct Context {
     packet_id: u8,
     transaction_id: u64,
     last_meta: Option<Arc<TokenColMetaData>>,
-    #[cfg(windows)]
     spn: Option<String>,
 }
 
@@ -21,7 +20,6 @@ impl Context {
             packet_id: 0,
             transaction_id: 0,
             last_meta: None,
-            #[cfg(windows)]
             spn: None,
         }
     }
@@ -60,12 +58,10 @@ impl Context {
         self.version
     }
 
-    #[cfg(windows)]
     pub fn set_spn(&mut self, host: impl AsRef<str>, port: u16) {
         self.spn = Some(format!("MSSQLSvc/{}:{}", host.as_ref(), port));
     }
 
-    #[cfg(windows)]
     pub fn spn(&self) -> &str {
         self.spn.as_ref().map(|s| s.as_str()).unwrap_or("")
     }

--- a/src/tds/stream/token.rs
+++ b/src/tds/stream/token.rs
@@ -51,6 +51,7 @@ where
         }
     }
 
+    #[cfg(any(windows, feature = "integrated-auth-gssapi"))]
     pub(crate) async fn flush_sspi(self) -> crate::Result<TokenSSPI> {
         let mut stream = self.try_unfold();
 

--- a/src/tds/stream/token.rs
+++ b/src/tds/stream/token.rs
@@ -1,4 +1,3 @@
-#[cfg(windows)]
 use crate::tds::codec::TokenSSPI;
 use crate::{
     client::Connection,
@@ -25,7 +24,6 @@ pub enum ReceivedToken {
     EnvChange(TokenEnvChange),
     Info(TokenInfo),
     LoginAck(TokenLoginAck),
-    #[cfg(windows)]
     SSPI(TokenSSPI),
 }
 
@@ -53,7 +51,6 @@ where
         }
     }
 
-    #[cfg(windows)]
     pub(crate) async fn flush_sspi(self) -> crate::Result<TokenSSPI> {
         let mut stream = self.try_unfold();
 
@@ -163,7 +160,6 @@ where
         Ok(ReceivedToken::LoginAck(ack))
     }
 
-    #[cfg(windows)]
     async fn get_sspi(&mut self) -> crate::Result<ReceivedToken> {
         let sspi = TokenSSPI::decode_async(self.conn).await?;
         event!(Level::TRACE, "SSPI response");
@@ -195,7 +191,6 @@ where
                 TokenType::EnvChange => this.get_env_change().await?,
                 TokenType::Info => this.get_info().await?,
                 TokenType::LoginAck => this.get_login_ack().await?,
-                #[cfg(windows)]
                 TokenType::SSPI => this.get_sspi().await?,
                 _ => panic!("Token {:?} unimplemented!", ty),
             };


### PR DESCRIPTION
This PR leverages the libgssapi crate to provide IntegratedSecurity support via Kerberos on Unix.

At the TDS protocol level, all the SSPI tokens/packets/etc are used for this, too, so I turned off the cfg(windows) for all of that machinery, and added the libgssapi dependency as cfg(unix). From a dependency perspective, though, could be nice to make it a dependency folks can turn off. Happy to adjust.

Anyhow, have a look and let me know what else this needs, if anything -- tested in a ActiveDirectory-based Kerberos environment with SQL Server.