### PR TITLE
Transactions 2

### DIFF
--- a/examples/tokio-transaction.rs
+++ b/examples/tokio-transaction.rs
@@ -1,0 +1,38 @@
+use once_cell::sync::Lazy;
+use std::env;
+use tiberius::{Client, Config};
+use tokio::net::TcpStream;
+use tokio_util::compat::Tokio02AsyncWriteCompatExt;
+
+static CONN_STR: Lazy<String> = Lazy::new(|| {
+    env::var("TIBERIUS_TEST_CONNECTION_STRING").unwrap_or_else(|_| {
+        "server=tcp:localhost,1433;IntegratedSecurity=true;TrustServerCertificate=true".to_owned()
+    })
+});
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let config = Config::from_ado_string(&CONN_STR)?;
+
+    let tcp = TcpStream::connect(config.get_addr()).await?;
+    tcp.set_nodelay(true)?;
+
+    let client = Client::connect(config, tcp.compat_write()).await?;
+
+    let (mut client, tran_res) = tiberius::transaction(client, |conn| async move { 
+         let _ = conn.execute(
+            "INSERT INTO #Test (id) VALUES (@P1), (@P2), (@P3)",
+            &[&1i32, &2i32, &3i32],
+        )
+        .await?;
+        Ok(())
+    }).await;
+
+    let stream = client.query("SELECT * from #Test", &[]).await?;
+    let row = stream.into_row().await?.unwrap();
+
+    println!("{:?}", row);
+    assert_eq!(Some(1), row.get(0));
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,9 +186,6 @@ mod tds;
 
 mod sql_browser;
 
-// TEMP
-pub use client::transaction;
-
 pub use client::{AuthMethod, Client, Config};
 pub(crate) use error::Error;
 pub use from_sql::{FromSql, FromSqlOwned};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,6 +186,9 @@ mod tds;
 
 mod sql_browser;
 
+// TEMP
+pub use client::transaction;
+
 pub use client::{AuthMethod, Client, Config};
 pub(crate) use error::Error;
 pub use from_sql::{FromSql, FromSqlOwned};


### PR DESCRIPTION
Experimenting with a potential API for transactions. The main idea here is to make it hard to accidentally drop the transaction, and hence end up in a state where the transaction never gets either committed or rolled back.

After opening the transaction with `Client::transaction` the resulting `Transaction` struct never returns errors until it is finalized with `Transaction::finalize`, and is also labelled `#[must_use]` to give compiler warnings if the transaction is never finalized.