### PR TITLE
Use connection-string for ado.net parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ pin-project-lite = "0.1"
 futures_codec = "0.4"
 futures-sink = "0.3"
 async-trait = "0.1"
+connection-string = "0.1.2"
 
 [target.'cfg(windows)'.dependencies]
 winauth = "0.0.4"

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -1,6 +1,5 @@
 use super::AuthMethod;
 use crate::EncryptionLevel;
-use std::collections::HashMap;
 
 #[derive(Clone, Debug)]
 /// The `Config` struct contains all configuration information
@@ -174,42 +173,13 @@ impl Config {
 }
 
 pub(crate) struct AdoNetString {
-    dict: HashMap<String, String>,
+    dict: connection_string::AdoNetString,
 }
 
 impl AdoNetString {
     pub fn parse(s: &str) -> crate::Result<Self> {
-        let dict: crate::Result<HashMap<String, String>> = s
-            .split(";")
-            .filter(|kv| kv != &"")
-            .map(|kv| {
-                let mut splitted = kv.split("=");
-
-                let key = splitted
-                    .next()
-                    .ok_or_else(|| {
-                        crate::Error::Conversion(
-                            "Missing a valid key in connection string parameters.".into(),
-                        )
-                    })?
-                    .trim()
-                    .to_lowercase();
-
-                let value = splitted
-                    .next()
-                    .ok_or_else(|| {
-                        crate::Error::Conversion(
-                            "Missing a valid value in connection string parameters.".into(),
-                        )
-                    })?
-                    .trim()
-                    .to_string();
-
-                Ok((key, value))
-            })
-            .collect();
-
-        Ok(Self { dict: dict? })
+        let dict = s.parse()?;
+        Ok(Self { dict })
     }
 
     pub fn server(&self) -> crate::Result<ServerDefinition> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -110,6 +110,13 @@ impl From<std::string::FromUtf16Error> for Error {
     }
 }
 
+impl From<connection_string::Error> for Error {
+    fn from(err: connection_string::Error) -> Error {
+        let err = Cow::Owned(format!("{}", err));
+        Error::Conversion(err)
+    }
+}
+
 #[cfg(feature = "integrated-auth-gssapi")]
 impl From<libgssapi::error::Error> for Error {
     fn from(err: libgssapi::error::Error) -> Error {


### PR DESCRIPTION
This replaces our `str.split(';')` parsing with a parser that's aware of escape sequences. This is required for correctly handling passwords that contain `;` characters. Thanks!