### PR TITLE
Lean and faster string writes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ futures_codec = "0.4"
 futures-sink = "0.3"
 async-trait = "0.1"
 connection-string = "0.1.4"
+ucs2 = "0.3"
 
 [target.'cfg(windows)'.dependencies]
 winauth = "0.0.4"

--- a/src/error.rs
+++ b/src/error.rs
@@ -58,6 +58,12 @@ pub enum Error {
     },
 }
 
+impl From<ucs2::Error> for Error {
+    fn from(_: ucs2::Error) -> Self {
+        Self::Utf16
+    }
+}
+
 impl From<uuid::Error> for Error {
     fn from(e: uuid::Error) -> Self {
         Self::Conversion(format!("Error convertiong a Guid value {}", e).into())

--- a/src/tds/codec/batch_request.rs
+++ b/src/tds/codec/batch_request.rs
@@ -24,9 +24,10 @@ impl<'a> Encode<BytesMut> for BatchRequest<'a> {
         dst.put_u64_le(self.transaction_id);
         dst.put_u32_le(1);
 
-        for c in self.queries.encode_utf16() {
+        ucs2::encode_with(&self.queries, |c| {
             dst.put_u16_le(c);
-        }
+            Ok(())
+        })?;
 
         Ok(())
     }

--- a/src/tds/codec/login.rs
+++ b/src/tds/codec/login.rs
@@ -233,9 +233,13 @@ impl<'a> Encode<BytesMut> for LoginMessage<'a> {
             let bak = cursor.position();
             cursor.set_position(data_offset as u64);
 
-            for codepoint in value.encode_utf16() {
-                cursor.write_u16::<LittleEndian>(codepoint)?;
-            }
+            ucs2::encode_with(&value, |codepoint| {
+                cursor
+                    .write_u16::<LittleEndian>(codepoint)
+                    .map_err(|_| ucs2::Error::BufferOverflow)?;
+
+                Ok(())
+            })?;
 
             let new_position = cursor.position() as usize;
 


### PR DESCRIPTION
- Allocates less: writes while encoding.
- Does not iterate all for getting the number of bytes.
- Uses ucs2 crate