### PR TITLE
Handle all MARS results properly

### DIFF
--- a/src/tds/codec/token/token_done.rs
+++ b/src/tds/codec/token/token_done.rs
@@ -45,6 +45,10 @@ impl TokenDone {
             done_rows,
         })
     }
+
+    pub(crate) fn has_more(&self) -> bool {
+        self.status.contains(DoneStatus::MORE)
+    }
 }
 
 impl fmt::Display for TokenDone {

--- a/src/tds/stream/query.rs
+++ b/src/tds/stream/query.rs
@@ -69,6 +69,7 @@ impl<'a> QueryStream<'a> {
                 Some(ReceivedToken::DoneInProc(_)) | Some(ReceivedToken::DoneProc(_)) => {
                     return Ok(());
                 }
+                Some(ReceivedToken::Done(done)) if done.has_more() => return Ok(()),
                 _ => {
                     if self.columns().is_none() {
                         self.state = QueryStreamState::Done;


### PR DESCRIPTION
If executing multiple statements, we must stream all results. The `Done` token holds information for later results, and we must not stop fetching until we have no more data left in the wire.