### PR TITLE
Do not swallow errors in simple query. Fixing transaction descriptors. Read envchanges correctly.

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -217,7 +217,7 @@ impl<S: AsyncRead + AsyncWrite + Unpin + Send> Client<S> {
     {
         self.connection.flush_stream().await?;
 
-        let req = BatchRequest::new(query, self.connection.context().transaction_id());
+        let req = BatchRequest::new(query, self.connection.context().transaction_descriptor());
 
         let id = self.connection.context_mut().next_packet_id();
         self.connection.send(PacketHeader::batch(id), req).await?;
@@ -278,7 +278,7 @@ impl<S: AsyncRead + AsyncWrite + Unpin + Send> Client<S> {
         let req = TokenRpcRequest::new(
             proc_id,
             rpc_params,
-            self.connection.context().transaction_id(),
+            self.connection.context().transaction_descriptor(),
         );
 
         let id = self.connection.context_mut().next_packet_id();

--- a/src/tds/codec/batch_request.rs
+++ b/src/tds/codec/batch_request.rs
@@ -4,14 +4,14 @@ use std::borrow::Cow;
 
 pub struct BatchRequest<'a> {
     queries: Cow<'a, str>,
-    transaction_id: u64,
+    transaction_descriptor: [u8; 8],
 }
 
 impl<'a> BatchRequest<'a> {
-    pub fn new(queries: impl Into<Cow<'a, str>>, transaction_id: u64) -> Self {
+    pub fn new(queries: impl Into<Cow<'a, str>>, transaction_descriptor: [u8; 8]) -> Self {
         Self {
             queries: queries.into(),
-            transaction_id,
+            transaction_descriptor,
         }
     }
 }
@@ -21,7 +21,7 @@ impl<'a> Encode<BytesMut> for BatchRequest<'a> {
         dst.put_u32_le(ALL_HEADERS_LEN_TX as u32);
         dst.put_u32_le(ALL_HEADERS_LEN_TX as u32 - 4);
         dst.put_u16_le(AllHeaderTy::TransactionDescriptor as u16);
-        dst.put_u64_le(self.transaction_id);
+        dst.put_slice(&self.transaction_descriptor);
         dst.put_u32_le(1);
 
         for c in self.queries.encode_utf16() {

--- a/src/tds/codec/rpc_request.rs
+++ b/src/tds/codec/rpc_request.rs
@@ -10,11 +10,11 @@ pub struct TokenRpcRequest<'a> {
     proc_id: RpcProcIdValue<'a>,
     flags: RpcOptionFlags,
     params: Vec<RpcParam<'a>>,
-    transaction_id: u64,
+    transaction_desc: [u8; 8],
 }
 
 impl<'a> TokenRpcRequest<'a> {
-    pub fn new<I>(proc_id: I, params: Vec<RpcParam<'a>>, transaction_id: u64) -> Self
+    pub fn new<I>(proc_id: I, params: Vec<RpcParam<'a>>, transaction_desc: [u8; 8]) -> Self
     where
         I: Into<RpcProcIdValue<'a>>,
     {
@@ -22,7 +22,7 @@ impl<'a> TokenRpcRequest<'a> {
             proc_id: proc_id.into(),
             flags: RpcOptionFlags::empty(),
             params,
-            transaction_id,
+            transaction_desc,
         }
     }
 }
@@ -95,7 +95,7 @@ impl<'a> Encode<BytesMut> for TokenRpcRequest<'a> {
         dst.put_u32_le(ALL_HEADERS_LEN_TX as u32);
         dst.put_u32_le(ALL_HEADERS_LEN_TX as u32 - 4);
         dst.put_u16_le(AllHeaderTy::TransactionDescriptor as u16);
-        dst.put_u64_le(self.transaction_id);
+        dst.put_slice(&self.transaction_desc);
         dst.put_u32_le(1);
 
         match self.proc_id {

--- a/src/tds/context.rs
+++ b/src/tds/context.rs
@@ -7,7 +7,7 @@ pub(crate) struct Context {
     version: FeatureLevel,
     packet_size: u32,
     packet_id: u8,
-    transaction_id: u64,
+    transaction_desc: [u8; 8],
     last_meta: Option<Arc<TokenColMetaData>>,
     spn: Option<String>,
 }
@@ -18,7 +18,7 @@ impl Context {
             version: FeatureLevel::SqlServerN,
             packet_size: 4096,
             packet_id: 0,
-            transaction_id: 0,
+            transaction_desc: [0; 8],
             last_meta: None,
             spn: None,
         }
@@ -46,12 +46,12 @@ impl Context {
         self.packet_size = new_size;
     }
 
-    pub fn transaction_id(&self) -> u64 {
-        self.transaction_id
+    pub fn transaction_descriptor(&self) -> [u8; 8] {
+        self.transaction_desc
     }
 
-    pub fn set_transaction_id(&mut self, id: u64) {
-        self.transaction_id = id;
+    pub fn set_transaction_descriptor(&mut self, desc: [u8; 8]) {
+        self.transaction_desc = desc;
     }
 
     pub fn version(&self) -> FeatureLevel {

--- a/src/tds/stream/query.rs
+++ b/src/tds/stream/query.rs
@@ -66,12 +66,10 @@ impl<'a> QueryStream<'a> {
 
                     return Ok(());
                 }
-                Some(ReceivedToken::DoneInProc(_)) | Some(ReceivedToken::DoneProc(_)) => {
-                    return Ok(());
-                }
-                Some(ReceivedToken::Done(done)) if done.has_more() => return Ok(()),
-                Some(ReceivedToken::Done(_)) => {
-                    if self.columns().is_none() {
+                Some(ReceivedToken::DoneInProc(done))
+                | Some(ReceivedToken::DoneProc(done))
+                | Some(ReceivedToken::Done(done)) => {
+                    if !done.has_more() {
                         self.state = QueryStreamState::Done;
                     }
 

--- a/src/tds/stream/query.rs
+++ b/src/tds/stream/query.rs
@@ -70,13 +70,14 @@ impl<'a> QueryStream<'a> {
                     return Ok(());
                 }
                 Some(ReceivedToken::Done(done)) if done.has_more() => return Ok(()),
-                _ => {
+                Some(ReceivedToken::Done(_)) => {
                     if self.columns().is_none() {
                         self.state = QueryStreamState::Done;
                     }
 
                     return Ok(());
                 }
+                _ => return Ok(()),
             }
         }
     }

--- a/src/tds/stream/token.rs
+++ b/src/tds/stream/token.rs
@@ -144,12 +144,12 @@ where
                 self.conn.context_mut().set_packet_size(new_size);
             }
             TokenEnvChange::BeginTransaction(desc) => {
-                self.conn.context_mut().set_transaction_id(desc);
+                self.conn.context_mut().set_transaction_descriptor(desc);
             }
-            TokenEnvChange::CommitTransaction(_)
-            | TokenEnvChange::RollbackTransaction(_)
-            | TokenEnvChange::DefectTransaction(_) => {
-                self.conn.context_mut().set_transaction_id(0);
+            TokenEnvChange::CommitTransaction
+            | TokenEnvChange::RollbackTransaction
+            | TokenEnvChange::DefectTransaction => {
+                self.conn.context_mut().set_transaction_descriptor([0; 8]);
             }
             _ => (),
         }


### PR DESCRIPTION
Fixing three bugs.

## Error swallowing

This fixes a problem where we might have warnings coming before errors in multiple resultset queries, when executing with `simple_query`.

Example:

```sql
CREATE UNIQUE INDEX [X] ON [table] ([column]);
```

In this case, if our column breaks unique validations, we'd expect `simple_query` to return an error.

If the column is of type `varchar` and the length is above threshold, the first token we get back is a warning of index size. We used to stop fetching data at this point, and our query would be successful even though we actually had an error in the wire.

## Transaction descriptor reading

Only the `BeginTransaction` holds the descriptor. Commit, rollback et.al. do not hold any data, and we can just zero the descriptor if having these events.

This has been causing weird bugs when running MARS with transactions somewhere in the middle.

## Environment change token reads

This was tricky. When we get `TokenEnvChange`, it's typically in the following form:

- length
- type
- data, usually having another length in the beginning

What we must do is to read ALL bytes first with the first length, then use this buffer to construct whatever token we need. There might be some bytes left in the buffer, which we just throw away in the end.