### PR TITLE
Fix a time conversion error

### DIFF
--- a/src/tds/time/chrono.rs
+++ b/src/tds/time/chrono.rs
@@ -13,6 +13,7 @@ use crate::tds::codec::ColumnData;
 #[cfg_attr(feature = "docs", doc(cfg(feature = "tds73")))]
 pub use chrono::offset::{FixedOffset, Utc};
 pub use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime};
+use std::ops::Sub;
 
 #[inline]
 fn from_days(days: i64, start_year: i32) -> NaiveDate {
@@ -72,19 +73,20 @@ from_sql!(
         ColumnData::DateTimeOffset(ref dto) => dto.map(|dto| {
             let date = from_days(dto.datetime2.date.days() as i64, 1);
             let ns = dto.datetime2.time.increments as i64 * 10i64.pow(9 - dto.datetime2.time.scale as u32);
+            let time = NaiveTime::from_hms(0,0,0) + chrono::Duration::nanoseconds(ns);
 
-            let time = NaiveTime::from_hms(0,0,0) + chrono::Duration::nanoseconds(ns) - chrono::Duration::minutes(dto.offset as i64);
-            let naive = NaiveDateTime::new(date, time);
+            let offset = chrono::Duration::minutes(dto.offset as i64);
+            let naive = NaiveDateTime::new(date, time).sub(offset);
 
             chrono::DateTime::from_utc(naive, Utc)
         });
     chrono::DateTime<FixedOffset>: ColumnData::DateTimeOffset(ref dto) => dto.map(|dto| {
         let date = from_days(dto.datetime2.date.days() as i64, 1);
         let ns = dto.datetime2.time.increments as i64 * 10i64.pow(9 - dto.datetime2.time.scale as u32);
-        let time = NaiveTime::from_hms(0,0,0) + chrono::Duration::nanoseconds(ns) - chrono::Duration::minutes(dto.offset as i64);
+        let time = NaiveTime::from_hms(0,0,0) + chrono::Duration::nanoseconds(ns);
 
         let offset = FixedOffset::east((dto.offset as i32) * 60);
-        let naive = NaiveDateTime::new(date, time);
+        let naive = NaiveDateTime::new(date, time).sub(offset);
 
         chrono::DateTime::from_utc(naive, offset)
     })


### PR DESCRIPTION
Previously the offset was subtracted from the time, before the date and
time were used to create a NaiveDateTime object. Then after the
NaiveDateTime object was created the offset was "added" again by means of
the `from_utc` method.

The problem with this approach is that if the offset is greater the
the time, you should actually go back a day in time. But since this action
was only done on the time, the date was not changed. So when the offset
was "added" again, the clock moved forward and added an additional day.

For example this object:

```rust
   DateTimeOffset {                                                                                                                                                                   │[I] ao                                                                                              10:28:20
        datetime2: DateTime2 {                                                                                                                                                         │➜ ~/code/heineken/terraform-aws-ft-brmx/functions aws:(be001oc-cb-datalayer) git:(master) ✗
            date: Date(                                                                                                                                                                │➜ ~/code/heineken/terraform-aws-ft-brmx/functions aws:(be001oc-cb-datalayer) git:(master) ✗
                737766,                                                                                                                                                                │[I] ssh -L 1433:10.22.76.10:1433 mi-0fe1490a4499e13df                                      (1.661s) 10:28:43
            ),                                                                                                                                                                         │Welcome to Ubuntu 18.04.2 LTS (GNU/Linux 4.15.0-54-generic x86_64)
            time: Time {                                                                                                                                                               │
                increments: 9310000000,                                                                                                                                                │ * Documentation:  https://help.ubuntu.com
                scale: 7,                                                                                                                                                              │ * Management:     https://landscape.canonical.com
            },                                                                                                                                                                         │ * Support:        https://ubuntu.com/advantage
        },                                                                                                                                                                             │
        offset: 60,                                                                                                                                                                    │  System information as of Wed Dec  9 09:30:55 UTC 2020
    }
```

Was parsed to `2020-12-09 00:15:31` while it should be `2020-12-08
00:15:31`

By first creating the NaiveDateTime object and the subtracting the
offset, it actually updates (if needed) the date as well preventing this
kind of error.