### PR TITLE
Implement reader functions for string data

### DIFF
--- a/src/sql_read_bytes.rs
+++ b/src/sql_read_bytes.rs
@@ -6,6 +6,92 @@ use std::io::ErrorKind::UnexpectedEof;
 use std::{future::Future, io, mem::size_of, pin::Pin, task};
 use task::Poll;
 
+macro_rules! varchar_reader {
+    ($name:ident, $length_reader:ident) => {
+        pin_project! {
+            #[doc(hidden)]
+            pub struct $name<R> {
+                #[pin]
+                src: R,
+                length: Option<usize>,
+                buf: Option<Vec<u16>>,
+                read: usize
+            }
+        }
+
+        #[allow(dead_code)]
+        impl<R> $name<R> {
+            pub(crate) fn new(src: R) -> Self {
+                Self {
+                    src,
+                    length: None,
+                    buf: None,
+                    read: 0,
+                }
+            }
+        }
+
+        impl<R> Future for $name<R>
+        where
+            R: AsyncRead,
+        {
+            type Output = io::Result<String>;
+
+            fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
+                let mut me = self.project();
+
+                // We must know the length of the string first.
+                while me.length.is_none() {
+                    let mut read_len = $length_reader::new(&mut me.src);
+
+                    match Pin::new(&mut read_len).poll(cx) {
+                        Poll::Pending => return Poll::Pending,
+                        Poll::Ready(Err(e)) => return Poll::Ready(Err(e.into())),
+                        Poll::Ready(Ok(length)) => {
+                            *me.length = Some(length as usize);
+                            *me.buf = Some(Vec::with_capacity(length as usize));
+                        }
+                    }
+                }
+
+                // We've set the length and initialized the buffer
+                let len = me.length.unwrap();
+                let buf = me.buf.as_mut().unwrap();
+
+                // Everything's read, we can return the string.
+                if *me.read == len {
+                    let s = String::from_utf16(&buf).map_err(|_| {
+                        io::Error::new(io::ErrorKind::InvalidData, "Invalid UTF-16 data.")
+                    })?;
+
+                    return Poll::Ready(Ok(s));
+                }
+
+                // Read the utf-16 data
+                while *me.read < len {
+                    let mut read_u16 = ReadU16Le::new(&mut me.src);
+
+                    match Pin::new(&mut read_u16).poll(cx) {
+                        Poll::Pending => return Poll::Pending,
+                        Poll::Ready(Err(e)) => return Poll::Ready(Err(e.into())),
+                        Poll::Ready(Ok(n)) => {
+                            buf.push(n);
+                            *me.read += 1;
+                        }
+                    }
+                }
+
+                // Everything's read, we can return the string.
+                let s = String::from_utf16(&buf).map_err(|_| {
+                    io::Error::new(io::ErrorKind::InvalidData, "Invalid UTF-16 data.")
+                })?;
+
+                return Poll::Ready(Ok(s));
+            }
+        }
+    };
+}
+
 macro_rules! bytes_reader {
     ($name:ident, $ty:ty, $reader:ident) => {
         bytes_reader!($name, $ty, $reader, size_of::<$ty>());
@@ -69,12 +155,16 @@ macro_rules! bytes_reader {
 }
 
 pub(crate) trait SqlReadBytes: AsyncRead + Unpin {
+    // Pretty-print current wire content.
     fn debug_buffer(&self);
 
+    // The client state.
     fn context(&self) -> &Context;
 
+    // A mutable reference to the SQL client state.
     fn context_mut(&mut self) -> &mut Context;
 
+    // Read a single i8 value.
     fn read_i8<'a>(&'a mut self) -> ReadI8<&'a mut Self>
     where
         Self: Unpin,
@@ -82,6 +172,7 @@ pub(crate) trait SqlReadBytes: AsyncRead + Unpin {
         ReadI8::new(self)
     }
 
+    // Read a single byte value.
     fn read_u8<'a>(&'a mut self) -> ReadU8<&'a mut Self>
     where
         Self: Unpin,
@@ -89,6 +180,7 @@ pub(crate) trait SqlReadBytes: AsyncRead + Unpin {
         ReadU8::new(self)
     }
 
+    // Read a single big-endian u32 value.
     fn read_u32<'a>(&'a mut self) -> ReadU32Be<&'a mut Self>
     where
         Self: Unpin,
@@ -96,6 +188,7 @@ pub(crate) trait SqlReadBytes: AsyncRead + Unpin {
         ReadU32Be::new(self)
     }
 
+    // Read a single big-endian f32 value.
     fn read_f32<'a>(&'a mut self) -> ReadF32<&'a mut Self>
     where
         Self: Unpin,
@@ -103,6 +196,7 @@ pub(crate) trait SqlReadBytes: AsyncRead + Unpin {
         ReadF32::new(self)
     }
 
+    // Read a single big-endian f64 value.
     fn read_f64<'a>(&'a mut self) -> ReadF64<&'a mut Self>
     where
         Self: Unpin,
@@ -110,6 +204,7 @@ pub(crate) trait SqlReadBytes: AsyncRead + Unpin {
         ReadF64::new(self)
     }
 
+    // Read a single f32 value.
     fn read_f32_le<'a>(&'a mut self) -> ReadF32Le<&'a mut Self>
     where
         Self: Unpin,
@@ -117,6 +212,7 @@ pub(crate) trait SqlReadBytes: AsyncRead + Unpin {
         ReadF32Le::new(self)
     }
 
+    // Read a single f64 value.
     fn read_f64_le<'a>(&'a mut self) -> ReadF64Le<&'a mut Self>
     where
         Self: Unpin,
@@ -124,6 +220,7 @@ pub(crate) trait SqlReadBytes: AsyncRead + Unpin {
         ReadF64Le::new(self)
     }
 
+    // Read a single u16 value.
     fn read_u16_le<'a>(&'a mut self) -> ReadU16Le<&'a mut Self>
     where
         Self: Unpin,
@@ -131,6 +228,7 @@ pub(crate) trait SqlReadBytes: AsyncRead + Unpin {
         ReadU16Le::new(self)
     }
 
+    // Read a single u32 value.
     fn read_u32_le<'a>(&'a mut self) -> ReadU32Le<&'a mut Self>
     where
         Self: Unpin,
@@ -138,6 +236,7 @@ pub(crate) trait SqlReadBytes: AsyncRead + Unpin {
         ReadU32Le::new(self)
     }
 
+    // Read a single u64 value.
     fn read_u64_le<'a>(&'a mut self) -> ReadU64Le<&'a mut Self>
     where
         Self: Unpin,
@@ -145,6 +244,7 @@ pub(crate) trait SqlReadBytes: AsyncRead + Unpin {
         ReadU64Le::new(self)
     }
 
+    // Read a single u128 value.
     fn read_u128_le<'a>(&'a mut self) -> ReadU128Le<&'a mut Self>
     where
         Self: Unpin,
@@ -152,6 +252,7 @@ pub(crate) trait SqlReadBytes: AsyncRead + Unpin {
         ReadU128Le::new(self)
     }
 
+    // Read a single i16 value.
     fn read_i16_le<'a>(&'a mut self) -> ReadI16Le<&'a mut Self>
     where
         Self: Unpin,
@@ -159,6 +260,7 @@ pub(crate) trait SqlReadBytes: AsyncRead + Unpin {
         ReadI16Le::new(self)
     }
 
+    // Read a single i32 value.
     fn read_i32_le<'a>(&'a mut self) -> ReadI32Le<&'a mut Self>
     where
         Self: Unpin,
@@ -166,6 +268,7 @@ pub(crate) trait SqlReadBytes: AsyncRead + Unpin {
         ReadI32Le::new(self)
     }
 
+    // Read a single i64 value.
     fn read_i64_le<'a>(&'a mut self) -> ReadI64Le<&'a mut Self>
     where
         Self: Unpin,
@@ -173,13 +276,33 @@ pub(crate) trait SqlReadBytes: AsyncRead + Unpin {
         ReadI64Le::new(self)
     }
 
+    // Read a single i128 value.
     fn read_i128_le<'a>(&'a mut self) -> ReadI128Le<&'a mut Self>
     where
         Self: Unpin,
     {
         ReadI128Le::new(self)
     }
+
+    // A variable-length character stream defined by a length-field of an u8.
+    fn read_b_varchar<'a>(&'a mut self) -> ReadBVarchar<&'a mut Self>
+    where
+        Self: Unpin,
+    {
+        ReadBVarchar::new(self)
+    }
+
+    // A variable-length character stream defined by a length-field of an u16.
+    fn read_us_varchar<'a>(&'a mut self) -> ReadUSVarchar<&'a mut Self>
+    where
+        Self: Unpin,
+    {
+        ReadUSVarchar::new(self)
+    }
 }
+
+varchar_reader!(ReadBVarchar, ReadU8);
+varchar_reader!(ReadUSVarchar, ReadU16Le);
 
 bytes_reader!(ReadI8, i8, get_i8);
 bytes_reader!(ReadU8, u8, get_u8);

--- a/src/tds/codec.rs
+++ b/src/tds/codec.rs
@@ -11,7 +11,6 @@ mod rpc_request;
 mod token;
 mod type_info;
 
-use crate::SqlReadBytes;
 pub use batch_request::*;
 use bytes::BytesMut;
 pub use column_data::*;
@@ -58,18 +57,4 @@ where
     }
 
     Ok(T::decode(&mut buf)?)
-}
-
-pub(crate) async fn read_varchar<R>(src: &mut R, len: impl Into<usize>) -> crate::Result<String>
-where
-    R: SqlReadBytes + Unpin,
-{
-    let len = len.into();
-    let mut buf = vec![0u16; len];
-
-    for i in 0..len {
-        buf[i] = src.read_u16_le().await?;
-    }
-
-    Ok(String::from_utf16(&buf[..])?)
 }

--- a/src/tds/codec/token/token_info.rs
+++ b/src/tds/codec/token/token_info.rs
@@ -1,4 +1,4 @@
-use crate::{tds::codec::read_varchar, SqlReadBytes};
+use crate::SqlReadBytes;
 
 #[derive(Debug)]
 pub struct TokenInfo {
@@ -25,18 +25,9 @@ impl TokenInfo {
             number: src.read_u32_le().await?,
             state: src.read_u8().await?,
             class: src.read_u8().await?,
-            message: {
-                let len = src.read_u16_le().await?;
-                read_varchar(src, len).await?
-            },
-            server: {
-                let len = src.read_u8().await?;
-                read_varchar(src, len).await?
-            },
-            procedure: {
-                let len = src.read_u8().await?;
-                read_varchar(src, len).await?
-            },
+            message: src.read_us_varchar().await?,
+            server: src.read_b_varchar().await?,
+            procedure: src.read_b_varchar().await?,
             line: src.read_u32_le().await?,
         };
 

--- a/src/tds/codec/token/token_login_ack.rs
+++ b/src/tds/codec/token/token_login_ack.rs
@@ -1,4 +1,4 @@
-use crate::{tds::codec::read_varchar, Error, FeatureLevel, SqlReadBytes};
+use crate::{Error, FeatureLevel, SqlReadBytes};
 use std::convert::TryFrom;
 
 #[derive(Debug)]
@@ -26,11 +26,7 @@ impl TokenLoginAck {
         let tds_version = FeatureLevel::try_from(src.read_u32().await?)
             .map_err(|_| Error::Protocol("Login ACK: Invalid TDS version".into()))?;
 
-        let prog_name = {
-            let len = src.read_u8().await?;
-            read_varchar(src, len).await?
-        };
-
+        let prog_name = src.read_b_varchar().await?;
         let version = src.read_u32_le().await?;
 
         Ok(TokenLoginAck {

--- a/src/tds/codec/token/token_return_value.rs
+++ b/src/tds/codec/token/token_return_value.rs
@@ -1,8 +1,5 @@
 use super::BaseMetaDataColumn;
-use crate::{
-    tds::codec::{read_varchar, ColumnData},
-    Error, SqlReadBytes,
-};
+use crate::{tds::codec::ColumnData, Error, SqlReadBytes};
 
 #[derive(Debug)]
 pub struct TokenReturnValue {
@@ -20,9 +17,7 @@ impl TokenReturnValue {
         R: SqlReadBytes + Unpin,
     {
         let param_ordinal = src.read_u16_le().await?;
-        let param_name_len = src.read_u8().await? as usize;
-
-        let param_name = read_varchar(src, param_name_len).await?;
+        let param_name = src.read_b_varchar().await?;
 
         let udf = match src.read_u8().await? {
             0x01 => false,

--- a/src/tds/codec/type_info.rs
+++ b/src/tds/codec/type_info.rs
@@ -132,14 +132,9 @@ impl TypeInfo {
                 let has_schema = src.read_u8().await?;
 
                 let schema = if has_schema == 1 {
-                    let len = src.read_u8().await?;
-                    let db_name = super::read_varchar(src, len).await?;
-
-                    let len = src.read_u8().await?;
-                    let owner = super::read_varchar(src, len).await?;
-
-                    let len = src.read_u16_le().await?;
-                    let collection = super::read_varchar(src, len).await?;
+                    let db_name = src.read_b_varchar().await?;
+                    let owner = src.read_b_varchar().await?;
+                    let collection = src.read_us_varchar().await?;
 
                     Some(Arc::new(XmlSchema::new(db_name, owner, collection)))
                 } else {


### PR DESCRIPTION
- `read_b_varchar` reads a u8-prefixed string from the wire.
- `read_us_varchar` reads a u16-prefixed string from the wire.