### PR TITLE
Add databaseName to the allowed keys in conn str

### DIFF
--- a/src/client/config.rs
+++ b/src/client/config.rs
@@ -240,6 +240,7 @@ pub(crate) trait ConfigString {
         self.dict()
             .get("database")
             .or_else(|| self.dict().get("initial catalog"))
+            .or_else(|| self.dict().get("databasename"))
             .map(|db| db.to_string())
     }
 

--- a/src/client/config/ado_net.rs
+++ b/src/client/config/ado_net.rs
@@ -132,6 +132,16 @@ mod tests {
 
         assert_eq!(Some("Foo".to_string()), ado.database());
 
+        let test_str = "databaseName=Foo";
+        let jdbc: AdoNetConfig = test_str.parse()?;
+
+        assert_eq!(Some("Foo".to_string()), jdbc.database());
+
+        let test_str = "Initial Catalog=Foo";
+        let jdbc: AdoNetConfig = test_str.parse()?;
+
+        assert_eq!(Some("Foo".to_string()), jdbc.database());
+
         Ok(())
     }
 

--- a/src/client/config/jdbc.rs
+++ b/src/client/config/jdbc.rs
@@ -97,6 +97,16 @@ mod tests {
 
         assert_eq!(Some("Foo".to_string()), jdbc.database());
 
+        let test_str = "jdbc:sqlserver://myserver.com:4200;databaseName=Foo";
+        let jdbc: JdbcConfig = test_str.parse()?;
+
+        assert_eq!(Some("Foo".to_string()), jdbc.database());
+
+        let test_str = "jdbc:sqlserver://myserver.com:4200;Initial Catalog=Foo";
+        let jdbc: JdbcConfig = test_str.parse()?;
+
+        assert_eq!(Some("Foo".to_string()), jdbc.database());
+
         Ok(())
     }
 


### PR DESCRIPTION
The database is now parsed from the following keys:

- database
- databaseName
- initial catalog

All keys case-insensitive.

Closes: https://github.com/prisma/tiberius/issues/99