### PR TITLE
Always compile with TLS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,10 +55,10 @@ winauth = "0.0.4"
 libgssapi = { version = "0.4", optional = true, default-features = false }
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
-tls-impl = { version = "0.1", optional = true, package = "opentls", features = ["io-async-std"]}
+opentls = { version = "0.1", features = ["io-async-std"]}
 
 [target.'cfg(not(any(target_os = "macos", target_os = "ios")))'.dependencies]
-tls-impl = { version = "0.3", optional = true, package = "async-native-tls", features = ["runtime-async-std"]}
+async-native-tls = { version = "0.3", features = ["runtime-async-std"]}
 
 [dependencies.tokio]
 version = "0.2"
@@ -133,7 +133,6 @@ features = ["all", "docs"]
 
 [features]
 all = [
-    "tls",
     "chrono",
     "tds73",
     "sql-browser-async-std",
@@ -142,16 +141,11 @@ all = [
     "rust_decimal",
     "bigdecimal"
 ]
-default = ["tls", "tds73"]
-tls = ["tls-impl"]
-vendored-openssl = ["tls-impl/vendored"]
+default = ["tds73"]
+vendored-openssl = ["opentls/vendored", "async-native-tls/vendored"]
 tds73 = []
 docs = []
-sql-browser-async-std = ["async-std"]
-sql-browser-tokio = ["tokio", "tokio-util"]
+sql-browser-async-std = ["async-std", "opentls/io-async-std", "async-native-tls/runtime-async-std"]
+sql-browser-tokio = ["tokio", "tokio-util", "opentls/io-tokio", "async-native-tls/runtime-tokio"]
 integrated-auth-gssapi = ["libgssapi"]
 bigdecimal = [ "bigdecimal_", "num-bigint" ]
-
-[dependencies.async-native-tls]
-optional = true
-version = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ winauth = "0.0.4"
 libgssapi = { version = "0.4", optional = true, default-features = false }
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
-opentls = { version = "0.1", features = ["io-async-std"]}
+opentls = { version = "0.1.3", features = ["io-async-std"]}
 
 [target.'cfg(not(any(target_os = "macos", target_os = "ios")))'.dependencies]
 async-native-tls = { version = "0.3", features = ["runtime-async-std"]}

--- a/src/client/config.rs
+++ b/src/client/config.rs
@@ -38,10 +38,7 @@ impl Default for Config {
             port: None,
             database: None,
             instance_name: None,
-            #[cfg(feature = "tls")]
             encryption: EncryptionLevel::Required,
-            #[cfg(not(feature = "tls"))]
-            encryption: EncryptionLevel::NotSupported,
             trust_cert: false,
             auth: AuthMethod::None,
         }
@@ -251,7 +248,6 @@ pub(crate) trait ConfigString {
             .unwrap_or(Ok(false))
     }
 
-    #[cfg(feature = "tls")]
     fn encrypt(&self) -> crate::Result<EncryptionLevel> {
         self.dict()
             .get("encrypt")
@@ -262,11 +258,6 @@ pub(crate) trait ConfigString {
                 Err(e) => Err(e)?,
             })
             .unwrap_or(Ok(EncryptionLevel::Off))
-    }
-
-    #[cfg(not(feature = "tls"))]
-    fn encrypt(&self) -> crate::Result<EncryptionLevel> {
-        Ok(EncryptionLevel::NotSupported)
     }
 
     fn parse_bool<T: AsRef<str>>(v: T) -> crate::Result<bool> {

--- a/src/client/config/ado_net.rs
+++ b/src/client/config/ado_net.rs
@@ -278,7 +278,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "tls")]
     fn encryption_parsing_on() -> crate::Result<()> {
         let test_str = "encrypt=true";
         let ado: AdoNetConfig = test_str.parse()?;
@@ -289,7 +288,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "tls")]
     fn encryption_parsing_off() -> crate::Result<()> {
         let test_str = "encrypt=false";
         let ado: AdoNetConfig = test_str.parse()?;
@@ -300,7 +298,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "tls")]
     fn encryption_parsing_plaintext() -> crate::Result<()> {
         let test_str = "encrypt=DANGER_PLAINTEXT";
         let ado: AdoNetConfig = test_str.parse()?;
@@ -311,56 +308,11 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "tls")]
     fn encryption_parsing_missing() -> crate::Result<()> {
         let test_str = "";
         let ado: AdoNetConfig = test_str.parse()?;
 
         assert_eq!(EncryptionLevel::Off, ado.encrypt()?);
-
-        Ok(())
-    }
-
-    #[test]
-    #[cfg(not(feature = "tls"))]
-    fn encryption_parsing_on() -> crate::Result<()> {
-        let test_str = "encrypt=true";
-        let ado: AdoNetConfig = test_str.parse()?;
-
-        assert_eq!(EncryptionLevel::NotSupported, ado.encrypt()?);
-
-        Ok(())
-    }
-
-    #[test]
-    #[cfg(not(feature = "tls"))]
-    fn encryption_parsing_off() -> crate::Result<()> {
-        let test_str = "encrypt=false";
-        let ado: AdoNetConfig = test_str.parse()?;
-
-        assert_eq!(EncryptionLevel::NotSupported, ado.encrypt()?);
-
-        Ok(())
-    }
-
-    #[test]
-    #[cfg(not(feature = "tls"))]
-    fn encryption_parsing_plaintext() -> crate::Result<()> {
-        let test_str = "encrypt=DANGER_PLAINTEXT";
-        let ado: AdoNetConfig = test_str.parse()?;
-
-        assert_eq!(EncryptionLevel::NotSupported, ado.encrypt()?);
-
-        Ok(())
-    }
-
-    #[test]
-    #[cfg(not(feature = "tls"))]
-    fn encryption_parsing_missing() -> crate::Result<()> {
-        let test_str = "";
-        let ado: AdoNetConfig = test_str.parse()?;
-
-        assert_eq!(EncryptionLevel::NotSupported, ado.encrypt()?);
 
         Ok(())
     }

--- a/src/client/config/jdbc.rs
+++ b/src/client/config/jdbc.rs
@@ -244,7 +244,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "tls")]
     fn encryption_parsing_on() -> crate::Result<()> {
         let test_str = "jdbc:sqlserver://my-server.com:4200;encrypt=true;";
         let jdbc: JdbcConfig = test_str.parse()?;
@@ -255,7 +254,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "tls")]
     fn encryption_parsing_off() -> crate::Result<()> {
         let test_str = "jdbc:sqlserver://my-server.com:4200;encrypt=false;";
         let jdbc: JdbcConfig = test_str.parse()?;
@@ -266,7 +264,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "tls")]
     fn encryption_parsing_plaintext() -> crate::Result<()> {
         let test_str = "jdbc:sqlserver://my-server.com:4200;encrypt=DANGER_PLAINTEXT;";
         let jdbc: JdbcConfig = test_str.parse()?;
@@ -277,56 +274,11 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "tls")]
     fn encryption_parsing_missing() -> crate::Result<()> {
         let test_str = "jdbc:sqlserver://my-server.com:4200;";
         let jdbc: JdbcConfig = test_str.parse()?;
 
         assert_eq!(EncryptionLevel::Off, jdbc.encrypt()?);
-
-        Ok(())
-    }
-
-    #[test]
-    #[cfg(not(feature = "tls"))]
-    fn encryption_parsing_on() -> crate::Result<()> {
-        let test_str = "jdbc:sqlserver://my-server.com:4200;encrypt=true;";
-        let jdbc: JdbcConfig = test_str.parse()?;
-
-        assert_eq!(EncryptionLevel::NotSupported, jdbc.encrypt()?);
-
-        Ok(())
-    }
-
-    #[test]
-    #[cfg(not(feature = "tls"))]
-    fn encryption_parsing_off() -> crate::Result<()> {
-        let test_str = "jdbc:sqlserver://my-server.com:4200;encrypt=false;";
-        let jdbc: JdbcConfig = test_str.parse()?;
-
-        assert_eq!(EncryptionLevel::NotSupported, jdbc.encrypt()?);
-
-        Ok(())
-    }
-
-    #[test]
-    #[cfg(not(feature = "tls"))]
-    fn encryption_parsing_missing() -> crate::Result<()> {
-        let test_str = "jdbc:sqlserver://my-server.com:4200;";
-        let jdbc: JdbcConfig = test_str.parse()?;
-
-        assert_eq!(EncryptionLevel::NotSupported, jdbc.encrypt()?);
-
-        Ok(())
-    }
-
-    #[test]
-    #[cfg(not(feature = "tls"))]
-    fn encryption_parsing_plaintext() -> crate::Result<()> {
-        let test_str = "jdbc:sqlserver://my-server.com:4200;encrypt=DANGER_PLAINTEXT;";
-        let jdbc: JdbcConfig = test_str.parse()?;
-
-        assert_eq!(EncryptionLevel::NotSupported, jdbc.encrypt()?);
 
         Ok(())
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -68,10 +68,24 @@ impl From<uuid::Error> for Error {
     }
 }
 
-#[cfg(feature = "tls")]
-#[cfg_attr(feature = "docs", doc(cfg(feature = "tls")))]
-impl From<tls_impl::Error> for Error {
-    fn from(v: tls_impl::Error) -> Self {
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg_attr(
+    feature = "docs",
+    doc(cfg(any(target_os = "macos", target_os = "ios")))
+)]
+impl From<opentls::Error> for Error {
+    fn from(v: opentls::Error) -> Self {
+        Error::Tls(format!("{}", v))
+    }
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
+#[cfg_attr(
+    feature = "docs",
+    doc(cfg(not(any(target_os = "macos", target_os = "ios"))))
+)]
+impl From<async_native_tls::Error> for Error {
+    fn from(v: async_native_tls::Error) -> Self {
         Error::Tls(format!("{}", v))
     }
 }

--- a/src/tds.rs
+++ b/src/tds.rs
@@ -14,7 +14,6 @@ pub(crate) use time::*;
 /// The amount of bytes a packet header consists of
 pub(crate) const HEADER_BYTES: usize = 8;
 
-#[cfg(feature = "tls")]
 uint_enum! {
     /// The configured encryption level specifying if encryption is required
     #[repr(u8)]
@@ -29,12 +28,4 @@ uint_enum! {
         Required = 3,
     }
 
-}
-
-#[cfg(not(feature = "tls"))]
-uint_enum! {
-    pub enum EncryptionLevel {
-        /// Do not encrypt anything
-        NotSupported = 2,
-    }
 }

--- a/src/tds/codec/pre_login.rs
+++ b/src/tds/codec/pre_login.rs
@@ -38,14 +38,11 @@ impl PreloginMessage {
             (EncryptionLevel::NotSupported, EncryptionLevel::NotSupported) => {
                 EncryptionLevel::NotSupported
             }
-            #[cfg(feature = "tls")]
             (EncryptionLevel::Off, EncryptionLevel::Off) => EncryptionLevel::Off,
-            #[cfg(feature = "tls")]
             (EncryptionLevel::On, EncryptionLevel::Off)
             | (EncryptionLevel::On, EncryptionLevel::NotSupported) => {
                 panic!("Server does not allow the requested encryption level.")
             }
-            #[cfg(feature = "tls")]
             (_, _) => EncryptionLevel::On,
         }
     }

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -26,14 +26,11 @@ async fn random_table() -> String {
     NAMES.lock().await.next().unwrap().replace('-', "")
 }
 
-#[cfg(feature = "tls")]
 static ENCRYPTED_CONN_STR: Lazy<String> = Lazy::new(|| format!("{};encrypt=true", *CONN_STR));
 
-#[cfg(feature = "tls")]
 static PLAIN_TEXT_CONN_STR: Lazy<String> =
     Lazy::new(|| format!("{};encrypt=DANGER_PLAINTEXT", *CONN_STR));
 
-#[cfg(feature = "tls")]
 #[test_on_runtimes(connection_string = "ENCRYPTED_CONN_STR")]
 async fn connect_with_full_encryption<S>(mut conn: tiberius::Client<S>) -> Result<()>
 where
@@ -51,7 +48,6 @@ where
     Ok(())
 }
 
-#[cfg(feature = "tls")]
 #[test_on_runtimes(connection_string = "PLAIN_TEXT_CONN_STR")]
 async fn connect_as_plain_text<S>(mut conn: tiberius::Client<S>) -> Result<()>
 where


### PR DESCRIPTION
Users can always not use TLS by setting a runtime parameter. This makes all feature flags much more straightforward. Otherwise we'd always build opentls even if we need native-tls, or always build native-tls even if needing opentls. And now we can also set the correct runtime feature for async-native-tls or opentls, so we don't need to build tokio if using async-std and so on...