### PR TITLE
Set server name in the login packet

### DIFF
--- a/src/tds/codec/decode.rs
+++ b/src/tds/codec/decode.rs
@@ -1,7 +1,7 @@
 use super::{Packet, PacketCodec, PacketHeader, HEADER_BYTES};
 use crate::Error;
-use bytes::{Buf, BytesMut};
 use asynchronous_codec::Decoder;
+use bytes::{Buf, BytesMut};
 use tracing::{event, Level};
 
 pub trait Decode<B: Buf> {

--- a/src/tds/codec/encode.rs
+++ b/src/tds/codec/encode.rs
@@ -1,6 +1,6 @@
 use super::{Packet, PacketCodec};
-use bytes::{BufMut, BytesMut};
 use asynchronous_codec::Encoder;
+use bytes::{BufMut, BytesMut};
 
 pub(crate) trait Encode<B: BufMut> {
     fn encode(self, dst: &mut B) -> crate::Result<()>;

--- a/src/tds/codec/login.rs
+++ b/src/tds/codec/login.rs
@@ -93,6 +93,7 @@ impl FeatureLevel {
 }
 
 /// the login packet
+#[derive(Debug)]
 pub struct LoginMessage<'a> {
     /// the highest TDS version the client supports
     pub tds_version: FeatureLevel,


### PR DESCRIPTION
This fixes a few things. First, connections to Azure SQL managed instances were not possible before. It complained we didn't set the server name with the user, even though our username was set as `user@server_name`. We actually need to specify the server name in the login packet too. I was able to connect successfully to the managed instance using this patch.

The second is the problem of redirects. In a case where we error on connect with:
```
Error: Server requested a connection to an alternative address: `asdf.database.windows.net:11006`
```
We should then modify our configuration to point to the new address, and try again. With this patch, this actually works and we can close https://github.com/prisma/tiberius/issues/88.