### PR TITLE
Try out all resolved IP addresses

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ async-native-tls = { version = "0.3", features = ["runtime-async-std"]}
 [dependencies.tokio]
 version = "1.0"
 optional = true
-features = ["net"]
+features = ["net", "time"]
 
 [dependencies.tokio-util]
 version = "0.6"

--- a/src/sql_browser/async_std.rs
+++ b/src/sql_browser/async_std.rs
@@ -13,52 +13,50 @@ impl SqlBrowser for net::TcpStream {
     /// when on a Windows platform with the `sql-browser-async-std` feature
     /// enabled. Please see the crate examples for more detailed examples.
     async fn connect_named(builder: &crate::client::Config) -> crate::Result<Self> {
-        let mut addr = builder
-            .get_addr()
-            .to_socket_addrs()
-            .await?
-            .next()
-            .ok_or_else(|| {
-                io::Error::new(io::ErrorKind::NotFound, "Could not resolve server host.")
-            })?;
+        let addrs = builder.get_addr().to_socket_addrs().await?;
 
-        if let Some(ref instance_name) = builder.instance_name {
-            // First resolve the instance to a port via the
-            // SSRP protocol/MS-SQLR protocol [1]
-            // [1] https://msdn.microsoft.com/en-us/library/cc219703.aspx
+        for mut addr in addrs {
+            if let Some(ref instance_name) = builder.instance_name {
+                // First resolve the instance to a port via the
+                // SSRP protocol/MS-SQLR protocol [1]
+                // [1] https://msdn.microsoft.com/en-us/library/cc219703.aspx
 
-            let local_bind: std::net::SocketAddr = if addr.is_ipv4() {
-                "0.0.0.0:0".parse().unwrap()
-            } else {
-                "[::]:0".parse().unwrap()
+                let local_bind: std::net::SocketAddr = if addr.is_ipv4() {
+                    "0.0.0.0:0".parse().unwrap()
+                } else {
+                    "[::]:0".parse().unwrap()
+                };
+
+                let msg = [&[4u8], instance_name.as_bytes()].concat();
+                let mut buf = vec![0u8; 4096];
+
+                let socket = net::UdpSocket::bind(&local_bind).await?;
+                socket.send_to(&msg, &addr).await?;
+
+                let timeout = time::Duration::from_millis(1000);
+
+                let len = io::timeout(timeout, socket.recv(&mut buf))
+                    .map_err(|_| {
+                        crate::error::Error::Conversion(
+                            format!(
+                                "SQL browser timeout during resolving instance {}",
+                                instance_name
+                            )
+                            .into(),
+                        )
+                    })
+                    .await?;
+
+                let port = super::get_port_from_sql_browser_reply(buf, len, instance_name)?;
+                addr.set_port(port);
             };
 
-            let msg = [&[4u8], instance_name.as_bytes()].concat();
-            let mut buf = vec![0u8; 4096];
+            if let Ok(stream) = net::TcpStream::connect(addr).await {
+                stream.set_nodelay(true)?;
+                return Ok(stream);
+            }
+        }
 
-            let socket = net::UdpSocket::bind(&local_bind).await?;
-            socket.send_to(&msg, &addr).await?;
-
-            let timeout = time::Duration::from_millis(1000);
-
-            let len = io::timeout(timeout, socket.recv(&mut buf))
-                .map_err(|_| {
-                    crate::error::Error::Conversion(
-                        format!(
-                            "SQL browser timeout during resolving instance {}",
-                            instance_name
-                        )
-                        .into(),
-                    )
-                })
-                .await?;
-
-            let port = super::get_port_from_sql_browser_reply(buf, len, instance_name)?;
-            addr.set_port(port);
-        };
-
-        let stream = net::TcpStream::connect(addr).await?;
-        stream.set_nodelay(true)?;
-        Ok(stream)
+        Err(io::Error::new(io::ErrorKind::NotFound, "Could not resolve server host.").into())
     }
 }

--- a/src/sql_browser/tokio.rs
+++ b/src/sql_browser/tokio.rs
@@ -3,9 +3,11 @@ use crate::client::Config;
 use async_trait::async_trait;
 use futures::TryFutureExt;
 use net::{TcpStream, UdpSocket};
-use std::{io, net::SocketAddr};
-use time::Duration;
-use tokio::{net, time};
+use std::io;
+use tokio::{
+    net,
+    time::{self, error::Elapsed, Duration},
+};
 
 #[async_trait]
 impl SqlBrowser for TcpStream {
@@ -13,51 +15,50 @@ impl SqlBrowser for TcpStream {
     /// when on a Windows paltform with the `sql-browser-tokio` feature
     /// enabled. Please see the crate examples for more detailed examples.
     async fn connect_named(builder: &Config) -> crate::Result<Self> {
-        let mut addr: SocketAddr = net::lookup_host(builder.get_addr())
-            .await?
-            .next()
-            .ok_or_else(|| {
-                io::Error::new(io::ErrorKind::NotFound, "Could not resolve server host.")
-            })?;
+        let addrs = net::lookup_host(builder.get_addr()).await?;
 
-        if let Some(ref instance_name) = builder.instance_name {
-            // First resolve the instance to a port via the
-            // SSRP protocol/MS-SQLR protocol [1]
-            // [1] https://msdn.microsoft.com/en-us/library/cc219703.aspx
+        for mut addr in addrs {
+            if let Some(ref instance_name) = builder.instance_name {
+                // First resolve the instance to a port via the
+                // SSRP protocol/MS-SQLR protocol [1]
+                // [1] https://msdn.microsoft.com/en-us/library/cc219703.aspx
 
-            let local_bind: std::net::SocketAddr = if addr.is_ipv4() {
-                "0.0.0.0:0".parse().unwrap()
-            } else {
-                "[::]:0".parse().unwrap()
+                let local_bind: std::net::SocketAddr = if addr.is_ipv4() {
+                    "0.0.0.0:0".parse().unwrap()
+                } else {
+                    "[::]:0".parse().unwrap()
+                };
+
+                let msg = [&[4u8], instance_name.as_bytes()].concat();
+                let mut buf = vec![0u8; 4096];
+
+                let socket = UdpSocket::bind(&local_bind).await?;
+                socket.send_to(&msg, &addr).await?;
+
+                let timeout = Duration::from_millis(1000);
+
+                let len = time::timeout(timeout, socket.recv(&mut buf))
+                    .map_err(|_: Elapsed| {
+                        crate::error::Error::Conversion(
+                            format!(
+                                "SQL browser timeout during resolving instance {}",
+                                instance_name
+                            )
+                            .into(),
+                        )
+                    })
+                    .await??;
+
+                let port = super::get_port_from_sql_browser_reply(buf, len, instance_name)?;
+                addr.set_port(port);
             };
 
-            let msg = [&[4u8], instance_name.as_bytes()].concat();
-            let mut buf = vec![0u8; 4096];
+            if let Ok(stream) = TcpStream::connect(addr).await {
+                stream.set_nodelay(true)?;
+                return Ok(stream);
+            }
+        }
 
-            let socket = UdpSocket::bind(&local_bind).await?;
-            socket.send_to(&msg, &addr).await?;
-
-            let timeout = Duration::from_millis(1000);
-
-            let len = time::timeout(timeout, socket.recv(&mut buf))
-                .map_err(|_| {
-                    crate::error::Error::Conversion(
-                        format!(
-                            "SQL browser timeout during resolving instance {}",
-                            instance_name
-                        )
-                        .into(),
-                    )
-                })
-                .await??;
-
-            let port = super::get_port_from_sql_browser_reply(buf, len, instance_name)?;
-            addr.set_port(port);
-        };
-
-        let stream = TcpStream::connect(addr).await?;
-        stream.set_nodelay(true)?;
-
-        Ok(stream)
+        Err(io::Error::new(io::ErrorKind::NotFound, "Could not resolve server host.").into())
     }
 }


### PR DESCRIPTION
On SQL Browser, we previously just tried the first resolved IP, and failed with connection refused if it didn't work. Now there's a docker bug that doesn't allow us to connect with `::1`, meaning using `localhost` with the docker image would tehn try to connect to `::1`, fail and stop the world.

Now we look into other addresses too, and try again if the first ones didn't work.