### PR TITLE
Split the client for automated rollback of transactions

### DIFF
--- a/examples/tokio-transaction-fnonce.rs
+++ b/examples/tokio-transaction-fnonce.rs
@@ -1,0 +1,80 @@
+use once_cell::sync::Lazy;
+use std::env;
+use tiberius::{ToSql, params, transaction, Config, Client};
+use tokio::net::TcpStream;
+use tokio_util::compat::TokioAsyncWriteCompatExt;
+
+static CONN_STR: Lazy<String> = Lazy::new(|| {
+    env::var("TIBERIUS_TEST_CONNECTION_STRING").unwrap_or_else(|_| {
+        "server=tcp:localhost,1433;IntegratedSecurity=true;TrustServerCertificate=true".to_owned()
+    })
+});
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let config = Config::from_ado_string(&CONN_STR)?;
+
+    let tcp = TcpStream::connect(config.get_addr()).await?;
+    tcp.set_nodelay(true)?;
+
+    let mut client = Client::connect(config, tcp.compat_write()).await?;
+
+    client.transaction(|conn| Box::pin(async move {
+
+        conn
+            .execute(
+                "delete from vegetables where name = @P1",
+                &[&"asparagus"],
+            )
+            .await?;
+        conn
+            .execute(
+                "insert into vegetables (name) values (@P1)",
+                &[&"cabbage"],
+            )
+            .await?;
+
+        Ok(())
+    })).await?;
+
+
+    transaction!(|client| async move {
+
+        client
+            .execute(
+                "delete from vegetables where name = @P1",
+                &[&"asparagus"],
+            )
+            .await?;
+        client
+            .execute(
+                "insert into vegetables (name) values (@P1)",
+                params!["cabbage"],
+            )
+            .await?;
+
+        Ok(())
+    });
+
+    let ext = String::new();
+
+    client.transaction_split(|mut conn| async move {
+        drop(ext);
+        conn
+            .execute(
+                "delete from vegetables where name = @P1",
+                &[&"asparagus"],
+            )
+            .await?;
+        conn
+            .execute(
+                "insert into vegetables (name) values (@P1)",
+                &[&"cabbage"],
+            )
+            .await?;
+
+        Ok(())
+    }).await?;
+
+    Ok(())
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,6 +16,12 @@ pub enum Error {
         /// The error description.
         message: String,
     },
+    /// An error occurred in the connection handling half of the split Client.
+    #[error(
+        "An error occurred within the split Client's connection handle half: {}",
+        _0
+    )]
+    SplitClient(String),
     #[error("Protocol error: {}", _0)]
     /// An error happened during the request or response parsing.
     Protocol(Cow<'static, str>),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -255,7 +255,7 @@ pub(crate) extern crate bigdecimal_ as bigdecimal;
 
 #[macro_use]
 mod macros;
-
+#[macro_use]
 mod client;
 mod from_sql;
 mod query;


### PR DESCRIPTION
A trial of using the same technique as `tokio-postgres` for transactions.

The user can spawn this in any runtime that supports spawning, so it still keeps us runtime agnostic as well.

@pimeys this is still a bit raw in terms of documentation, tests and efficiency (and lack of shared code between the client implementations), so its more of a proof of concept at this stage, but if you are happy with this approach in general I'll push some more commits to clean it up

