### PR TITLE
Nix shell setup

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,5 @@
 export TIBERIUS_TEST_CONNECTION_STRING="server=tcp:localhost,1433;user=SA;password=<YourStrong@Passw0rd>;TrustServerCertificate=true"
+if command -v nix-shell &> /dev/null
+then
+    use nix
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 Cargo.lock
 .idea
+.direnv/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ num-traits = "0.2"
 winauth = "0.0.4"
 
 [target.'cfg(unix)'.dependencies]
-libgssapi = { version = "0.4.4", optional = true, default-features = false }
+libgssapi = { version = "0.4.5", optional = true, default-features = false }
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 opentls = { version = "0.2.1", features = ["io-async-std"]}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,14 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+with pkgs;
+
+mkShell {
+  LIBCLANG_PATH="${pkgs.llvmPackages.libclang}/lib";
+  buildInputs = with pkgs; [
+    openssl
+    pkg-config
+    clangStdenv
+    llvmPackages.libclang
+    kerberos
+  ];
+}


### PR DESCRIPTION
If using Nix/NixOS, adds the needed shell environment to compile all features of Tiberius.

Either run

```bash
> nix-shell develop
```

or if using direnv, enable nix/shell integrations with home-manager:

```nix
direnv = {
  enable = true;
  enableFishIntegration = true;
  enableNixDirenvIntegration = true;
};
```