### PR TITLE
Warnings should not affect metadata fetching

### DIFF
--- a/src/row.rs
+++ b/src/row.rs
@@ -24,7 +24,7 @@ impl Column {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 /// The type of the column.
 pub enum ColumnType {
     /// The column doesn't have a specified type.

--- a/src/tds/stream/query.rs
+++ b/src/tds/stream/query.rs
@@ -50,31 +50,36 @@ impl<'a> QueryStream<'a> {
     }
 
     pub(crate) async fn fetch_metadata(&mut self) -> crate::Result<()> {
-        match self.token_stream.try_next().await? {
-            Some(ReceivedToken::NewResultset(meta)) => {
-                let columns = meta
-                    .columns
-                    .iter()
-                    .map(|x| Column {
-                        name: x.col_name.clone(),
-                        column_type: ColumnType::from(&x.base.ty),
-                    })
-                    .collect::<Vec<_>>();
+        loop {
+            match self.token_stream.try_next().await? {
+                Some(ReceivedToken::NewResultset(meta)) => {
+                    let columns = meta
+                        .columns
+                        .iter()
+                        .map(|x| Column {
+                            name: x.col_name.clone(),
+                            column_type: ColumnType::from(&x.base.ty),
+                        })
+                        .collect::<Vec<_>>();
 
-                self.store_columns(columns);
+                    self.store_columns(columns);
 
-                return Ok(());
-            }
-            Some(ReceivedToken::DoneInProc(done))
-            | Some(ReceivedToken::DoneProc(done))
-            | Some(ReceivedToken::Done(done)) => {
-                if !done.has_more() {
-                    self.state = QueryStreamState::Done;
+                    return Ok(());
                 }
+                Some(ReceivedToken::DoneInProc(done))
+                | Some(ReceivedToken::DoneProc(done))
+                | Some(ReceivedToken::Done(done)) => {
+                    if !done.has_more() {
+                        self.state = QueryStreamState::Done;
+                    }
 
-                return Ok(());
+                    return Ok(());
+                }
+                Some(ReceivedToken::Info(_)) => {
+                    continue;
+                }
+                _ => return Ok(()),
             }
-            _ => return Ok(()),
         }
     }
 


### PR DESCRIPTION
In some cases queries can trigger warnings, and this lead to faulty metadata (e.g. missing columns).

Closes: https://github.com/prisma/tiberius/issues/133