### PR TITLE
Add Config parsing for "Integrated Security" (two words)

### DIFF
--- a/src/client/config.rs
+++ b/src/client/config.rs
@@ -215,7 +215,11 @@ pub(crate) trait ConfigString {
             .or_else(|| self.dict().get("pwd"))
             .map(|s| s.as_str());
 
-        match self.dict().get("integratedsecurity") {
+        match self
+            .dict()
+            .get("integratedsecurity")
+            .or_else(|| self.dict().get("integrated security"))
+        {
             #[cfg(windows)]
             Some(val) if val.to_lowercase() == "sspi" || Self::parse_bool(val)? => match (user, pw)
             {

--- a/src/client/config/ado_net.rs
+++ b/src/client/config/ado_net.rs
@@ -226,6 +226,11 @@ mod tests {
 
         assert_eq!(AuthMethod::Integrated, ado.authentication()?);
 
+        let test_str = "Integrated Security=SSPI;";
+        let ado: AdoNetConfig = test_str.parse()?;
+
+        assert_eq!(AuthMethod::Integrated, ado.authentication()?);
+
         Ok(())
     }
 
@@ -237,6 +242,11 @@ mod tests {
 
         assert_eq!(AuthMethod::Integrated, ado.authentication()?);
 
+        let test_str = "Integrated Security=true;";
+        let ado: AdoNetConfig = test_str.parse()?;
+
+        assert_eq!(AuthMethod::Integrated, ado.authentication()?);
+
         Ok(())
     }
 
@@ -244,6 +254,14 @@ mod tests {
     #[cfg(windows)]
     fn parsing_windows_authentication() -> crate::Result<()> {
         let test_str = "uid=Musti;pwd=Naukio; IntegratedSecurity=SSPI;";
+        let ado: AdoNetConfig = test_str.parse()?;
+
+        assert_eq!(
+            AuthMethod::windows("Musti", "Naukio"),
+            ado.authentication()?
+        );
+
+        let test_str = "uid=Musti;pwd=Naukio; Integrated Security=SSPI;";
         let ado: AdoNetConfig = test_str.parse()?;
 
         assert_eq!(


### PR DESCRIPTION
Support for parsing "integratedsecurity" was already done correctly. I have added the possibility to parse "integrated security" as well.

The tests have been modified to check if it works correctly.