### PR TITLE
Add data source, dot syntax for server and fix crash when port is missing (fallback on the default port)

### DIFF
--- a/src/client/config.rs
+++ b/src/client/config.rs
@@ -110,7 +110,10 @@ impl Config {
     }
 
     pub(crate) fn get_host(&self) -> &str {
-        self.host.as_deref().unwrap_or("localhost")
+        self.host
+            .as_deref()
+            .filter(|v| v != &".")
+            .unwrap_or("localhost")
     }
 
     pub(crate) fn get_port(&self) -> u16 {

--- a/src/client/config/ado_net.rs
+++ b/src/client/config/ado_net.rs
@@ -122,6 +122,27 @@ mod tests {
     }
 
     #[test]
+    fn server_parsing_no_port() -> crate::Result<()> {
+        let test_str = "server=tcp:my-server.com";
+        let ado: AdoNetConfig = test_str.parse()?;
+        let server = ado.server()?;
+
+        assert_eq!(Some("my-server.com".to_string()), server.host);
+        assert_eq!(Some(1433), server.port);
+        assert_eq!(None, server.instance);
+
+        let test_str = "server=my-server.com";
+        let ado: AdoNetConfig = test_str.parse()?;
+        let server = ado.server()?;
+
+        assert_eq!(Some("my-server.com".to_string()), server.host);
+        assert_eq!(Some(1433), server.port);
+        assert_eq!(None, server.instance);
+
+        Ok(())
+    }
+
+    #[test]
     fn server_parsing_with_browser() -> crate::Result<()> {
         let test_str = "server=tcp:my-server.com\\TIBERIUS";
         let ado: AdoNetConfig = test_str.parse()?;


### PR DESCRIPTION
Multiple fixes:

- Parse of `data source=` in AdoConfig which is the same as `server=`
- Support for dot syntax: `.` which is the same as `localhost`
- Fix crash when port is missing inside the server address. Fallback on the default port which are:
   - 1433 for std tcp connection
   - 1434 for resolving instances
   
 I have add tests to reflect the changes.