### PR TITLE
Parse instance name from ADO connection string, regardless of platform

### DIFF
--- a/src/client/config.rs
+++ b/src/client/config.rs
@@ -176,9 +176,8 @@ impl Config {
             builder.port(port);
         }
 
-        if let Some(_instance) = server.instance {
-            #[cfg(windows)]
-            builder.instance_name(_instance);
+        if let Some(instance) = server.instance {
+            builder.instance_name(instance);
         }
 
         builder.authentication(s.authentication()?);


### PR DESCRIPTION
Sql Browser works fine on non-windows platforms (at least Linux), so there is no reason to limit parsing out the instance name to Windows.