### PR TITLE
Handle collations for CHAR and TEXT values

### DIFF
--- a/src/tds/codec/token/token_col_metadata.rs
+++ b/src/tds/codec/token/token_col_metadata.rs
@@ -176,10 +176,6 @@ impl BaseMetaDataColumn {
 
         match ty {
             TypeInfo::VarLenSized(VarLenType::Text, _, _) => {
-                src.read_u16_le().await?;
-                src.read_u16_le().await?;
-                src.read_u8().await?;
-
                 let num_of_parts = src.read_u8().await?;
 
                 // table name

--- a/src/tds/codec/type_info.rs
+++ b/src/tds/codec/type_info.rs
@@ -176,6 +176,7 @@ impl TypeInfo {
 
                 let collation = match ty {
                     VarLenType::NText
+                    | VarLenType::Text
                     | VarLenType::BigChar
                     | VarLenType::NChar
                     | VarLenType::NVarchar


### PR DESCRIPTION
So... Everybody uses the N variants to store non-ASCII data? No?

This fixes some wild assumptions:
- `CHAR` has always only ASCII data
- And `TEXT` too.

If not, well, of course the user uses `NCHAR` and `NTEXT`, right?

So, instead of just blindly converting the data to UTF-8, we actually use the given collation codepage, and use it to translate the string to UTF-8.

Part of fixing: https://github.com/prisma/prisma/issues/7476