### PR TITLE
Split column decoding into modules

### DIFF
--- a/src/row.rs
+++ b/src/row.rs
@@ -116,7 +116,7 @@ impl From<&TypeInfo> for ColumnType {
                 FixedLenType::Int8 => Self::Int8,
                 FixedLenType::Null => Self::Null,
             },
-            TypeInfo::VarLenSized(vlt, _, _) => match vlt {
+            TypeInfo::VarLenSized(cx) => match cx.r#type() {
                 VarLenType::Guid => Self::Guid,
                 VarLenType::Intn => Self::Intn,
                 VarLenType::Bitn => Self::Bitn,

--- a/src/tds/codec/column_data.rs
+++ b/src/tds/codec/column_data.rs
@@ -1,21 +1,35 @@
+mod binary;
+mod bit;
+#[cfg(feature = "tds73")]
+mod date;
+#[cfg(feature = "tds73")]
+mod datetime2;
+mod datetimen;
+#[cfg(feature = "tds73")]
+mod datetimeoffsetn;
+mod fixed_len;
+mod float;
+mod guid;
+mod image;
+mod int;
+mod money;
+mod plp;
+mod string;
+mod text;
+#[cfg(feature = "tds73")]
+mod time;
+mod var_len;
+mod xml;
+
 use super::{Encode, FixedLenType, TypeInfo, VarLenType};
-use crate::tds::{Collation, DateTime, SmallDateTime};
 #[cfg(feature = "tds73")]
 use crate::tds::{Date, DateTime2, DateTimeOffset, Time};
 use crate::{
-    tds::{
-        codec::guid,
-        xml::{XmlData, XmlSchema},
-        Numeric,
-    },
-    Error, SqlReadBytes,
+    tds::{xml::XmlData, DateTime, Numeric, SmallDateTime},
+    SqlReadBytes,
 };
-use byteorder::{ByteOrder, LittleEndian};
 use bytes::{BufMut, BytesMut};
-use encoding::DecoderTrap;
-use futures::io::AsyncReadExt;
-use std::borrow::BorrowMut;
-use std::{borrow::Cow, sync::Arc};
+use std::borrow::{BorrowMut, Cow};
 use uuid::Uuid;
 
 const MAX_NVARCHAR_SIZE: usize = 1 << 30;
@@ -105,587 +119,24 @@ impl<'a> ColumnData<'a> {
             ColumnData::DateTimeOffset(_) => "datetimeoffset".into(),
         }
     }
-}
 
-/// Mode for type reader.
-#[derive(Debug, Clone, Copy)]
-pub enum ReadTyMode {
-    /// Fixed-size type with given size
-    FixedSize(usize),
-    /// Partially length-prefixed type
-    Plp,
-}
-
-impl ReadTyMode {
-    /// Determine the mode automatically from size
-    pub fn auto(size: usize) -> Self {
-        if size < 0xffff {
-            ReadTyMode::FixedSize(size)
-        } else {
-            ReadTyMode::Plp
-        }
-    }
-}
-
-/// A partially read type
-#[derive(Debug)]
-pub struct ReadTyState {
-    pub(crate) mode: ReadTyMode,
-    pub(crate) data: Option<Vec<u8>>,
-    pub(crate) chunk_data_left: usize,
-}
-
-impl ReadTyState {
-    /// Initialize a type reader
-    pub fn new(mode: ReadTyMode) -> Self {
-        ReadTyState {
-            mode,
-            data: None,
-            chunk_data_left: 0,
-        }
-    }
-}
-
-#[derive(Clone, Debug, Copy)]
-pub struct VariableLengthContext {
-    ty: VarLenType,
-    len: usize,
-    collation: Option<Collation>,
-}
-
-#[derive(Clone, Debug, Copy)]
-pub struct VariableLengthPrecisionContext {
-    pub scale: u8,
-}
-
-impl VariableLengthContext {
-    pub fn new(ty: VarLenType, len: usize, collation: Option<Collation>) -> Self {
-        Self { ty, len, collation }
-    }
-}
-
-impl<'a> ColumnData<'a> {
     pub(crate) async fn decode<R>(src: &mut R, ctx: &TypeInfo) -> crate::Result<ColumnData<'a>>
     where
         R: SqlReadBytes + Unpin,
     {
         let res = match ctx {
-            TypeInfo::FixedLen(fixed_ty) => Self::decode_fixed_len(src, &fixed_ty).await?,
-            TypeInfo::VarLenSized(ty, max_len, collation) => {
-                let context = VariableLengthContext::new(*ty, *max_len, *collation);
-                Self::decode_var_len(src, &context).await?
-            }
+            TypeInfo::FixedLen(fixed_ty) => fixed_len::decode(src, &fixed_ty).await?,
+            TypeInfo::VarLenSized(cx) => var_len::decode(src, &cx).await?,
             TypeInfo::VarLenSizedPrecision { ty, scale, .. } => match ty {
                 VarLenType::Decimaln | VarLenType::Numericn => {
                     ColumnData::Numeric(Numeric::decode(src, *scale).await?)
                 }
                 _ => todo!(),
             },
-            TypeInfo::Xml { schema, size } => Self::decode_xml(src, *size, schema.clone()).await?,
+            TypeInfo::Xml { schema, size } => xml::decode(src, *size, schema.clone()).await?,
         };
 
         Ok(res)
-    }
-
-    async fn decode_fixed_len<R>(src: &mut R, ty: &FixedLenType) -> crate::Result<ColumnData<'a>>
-    where
-        R: SqlReadBytes + Unpin,
-    {
-        let ret = match ty {
-            FixedLenType::Null => ColumnData::Bit(None),
-            FixedLenType::Bit => ColumnData::Bit(Some(src.read_u8().await? != 0)),
-            FixedLenType::Int1 => ColumnData::U8(Some(src.read_u8().await?)),
-            FixedLenType::Int2 => ColumnData::I16(Some(src.read_i16_le().await?)),
-            FixedLenType::Int4 => ColumnData::I32(Some(src.read_i32_le().await?)),
-            FixedLenType::Int8 => ColumnData::I64(Some(src.read_i64_le().await?)),
-            FixedLenType::Float4 => ColumnData::F32(Some(src.read_f32_le().await?)),
-            FixedLenType::Float8 => ColumnData::F64(Some(src.read_f64_le().await?)),
-            FixedLenType::Datetime => Self::decode_datetimen(src, 8).await?,
-            FixedLenType::Datetime4 => Self::decode_datetimen(src, 4).await?,
-            FixedLenType::Money4 => Self::decode_money(src, 4).await?,
-            FixedLenType::Money => Self::decode_money(src, 8).await?,
-        };
-
-        Ok(ret)
-    }
-
-    async fn decode_var_len<R>(
-        src: &mut R,
-        ctx: &VariableLengthContext,
-    ) -> crate::Result<ColumnData<'a>>
-    where
-        R: SqlReadBytes + Unpin,
-    {
-        let ty = ctx.ty;
-        let len = ctx.len;
-        let collation = ctx.collation;
-
-        let res = match ty {
-            VarLenType::Bitn => Self::decode_bit(src).await?,
-            VarLenType::Intn => Self::decode_int(src).await?,
-            // 2.2.5.5.1.5 IEEE754
-            VarLenType::Floatn => Self::decode_float(src).await?,
-            VarLenType::Guid => Self::decode_guid(src).await?,
-            VarLenType::BigChar | VarLenType::NChar | VarLenType::NVarchar => {
-                let decoded = Self::decode_variable_string(src, ty, len, collation)
-                    .await?
-                    .map(Cow::from);
-
-                ColumnData::String(decoded)
-            }
-            VarLenType::BigVarChar => Self::decode_big_varchar(src, len, collation).await?,
-
-            VarLenType::Money => {
-                let len = src.read_u8().await?;
-                Self::decode_money(src, len).await?
-            }
-
-            VarLenType::Datetimen => {
-                let len = src.read_u8().await?;
-                Self::decode_datetimen(src, len).await?
-            }
-
-            #[cfg(feature = "tds73")]
-            VarLenType::Daten => Self::decode_date(src).await?,
-
-            #[cfg(feature = "tds73")]
-            VarLenType::Timen => {
-                let rlen = src.read_u8().await?;
-
-                match rlen {
-                    0 => ColumnData::Time(None),
-                    _ => {
-                        let time = Time::decode(src, len as usize, rlen as usize).await?;
-                        ColumnData::Time(Some(time))
-                    }
-                }
-            }
-
-            #[cfg(feature = "tds73")]
-            VarLenType::Datetime2 => {
-                let rlen = src.read_u8().await?;
-                match rlen {
-                    0 => ColumnData::DateTime2(None),
-                    rlen => {
-                        let dt = DateTime2::decode(src, len as usize, rlen as usize - 3).await?;
-                        ColumnData::DateTime2(Some(dt))
-                    }
-                }
-            }
-
-            #[cfg(feature = "tds73")]
-            VarLenType::DatetimeOffsetn => {
-                let rlen = src.read_u8().await?;
-
-                match rlen {
-                    0 => ColumnData::DateTimeOffset(None),
-                    _ => {
-                        let dto = DateTimeOffset::decode(src, len, rlen - 5).await?;
-                        ColumnData::DateTimeOffset(Some(dto))
-                    }
-                }
-            }
-
-            VarLenType::BigBinary | VarLenType::BigVarBin => Self::decode_binary(src, len).await?,
-            VarLenType::Text => Self::decode_text(src, collation).await?,
-            VarLenType::NText => Self::decode_ntext(src).await?,
-            VarLenType::Image => Self::decode_image(src).await?,
-            t => unimplemented!("{:?}", t),
-        };
-
-        Ok(res)
-    }
-
-    async fn decode_xml<R>(
-        src: &mut R,
-        len: usize,
-        schema: Option<Arc<XmlSchema>>,
-    ) -> crate::Result<ColumnData<'a>>
-    where
-        R: SqlReadBytes + Unpin,
-    {
-        let xml = Self::decode_variable_string(src, VarLenType::Xml, len, None)
-            .await?
-            .map(|data| {
-                let mut data = XmlData::new(data);
-
-                if let Some(schema) = schema {
-                    data.set_schema(schema);
-                }
-
-                Cow::Owned(data)
-            });
-
-        Ok(ColumnData::Xml(xml))
-    }
-
-    #[cfg(feature = "tds73")]
-    async fn decode_date<R>(src: &mut R) -> crate::Result<ColumnData<'static>>
-    where
-        R: SqlReadBytes + Unpin,
-    {
-        let len = src.read_u8().await?;
-
-        let res = match len {
-            0 => ColumnData::Date(None),
-            3 => ColumnData::Date(Some(Date::decode(src).await?)),
-            _ => {
-                return Err(Error::Protocol(
-                    format!("daten: length of {} is invalid", len).into(),
-                ))
-            }
-        };
-
-        Ok(res)
-    }
-
-    async fn decode_datetimen<R>(src: &mut R, len: u8) -> crate::Result<ColumnData<'static>>
-    where
-        R: SqlReadBytes + Unpin,
-    {
-        let datetime = match len {
-            0 => ColumnData::SmallDateTime(None),
-            4 => ColumnData::SmallDateTime(Some(SmallDateTime::decode(src).await?)),
-            8 => ColumnData::DateTime(Some(DateTime::decode(src).await?)),
-            _ => {
-                return Err(Error::Protocol(
-                    format!("datetimen: length of {} is invalid", len).into(),
-                ))
-            }
-        };
-
-        Ok(datetime)
-    }
-
-    async fn decode_bit<R>(src: &mut R) -> crate::Result<ColumnData<'static>>
-    where
-        R: SqlReadBytes + Unpin,
-    {
-        let recv_len = src.read_u8().await? as usize;
-
-        let res = match recv_len {
-            0 => ColumnData::Bit(None),
-            1 => ColumnData::Bit(Some(src.read_u8().await? > 0)),
-            v => {
-                return Err(Error::Protocol(
-                    format!("bitn: length of {} is invalid", v).into(),
-                ))
-            }
-        };
-
-        Ok(res)
-    }
-
-    async fn decode_int<R>(src: &mut R) -> crate::Result<ColumnData<'static>>
-    where
-        R: SqlReadBytes + Unpin,
-    {
-        let recv_len = src.read_u8().await? as usize;
-
-        let res = match recv_len {
-            0 => ColumnData::U8(None),
-            1 => ColumnData::U8(Some(src.read_u8().await?)),
-            2 => ColumnData::I16(Some(src.read_i16_le().await?)),
-            4 => ColumnData::I32(Some(src.read_i32_le().await?)),
-            8 => ColumnData::I64(Some(src.read_i64_le().await?)),
-            _ => unimplemented!(),
-        };
-
-        Ok(res)
-    }
-
-    async fn decode_float<R>(src: &mut R) -> crate::Result<ColumnData<'static>>
-    where
-        R: SqlReadBytes + Unpin,
-    {
-        let len = src.read_u8().await? as usize;
-
-        let res = match len {
-            0 => ColumnData::F32(None),
-            4 => ColumnData::F32(Some(src.read_f32_le().await?)),
-            8 => ColumnData::F64(Some(src.read_f64_le().await?)),
-            _ => {
-                return Err(Error::Protocol(
-                    format!("floatn: length of {} is invalid", len).into(),
-                ))
-            }
-        };
-
-        Ok(res)
-    }
-
-    async fn decode_guid<R>(src: &mut R) -> crate::Result<ColumnData<'static>>
-    where
-        R: SqlReadBytes + Unpin,
-    {
-        let len = src.read_u8().await? as usize;
-
-        let res = match len {
-            0 => ColumnData::Guid(None),
-            16 => {
-                let mut data = [0u8; 16];
-
-                for item in &mut data {
-                    *item = src.read_u8().await?;
-                }
-
-                guid::reorder_bytes(&mut data);
-                ColumnData::Guid(Some(Uuid::from_bytes(data)))
-            }
-            _ => {
-                return Err(Error::Protocol(
-                    format!("guid: length of {} is invalid", len).into(),
-                ))
-            }
-        };
-
-        Ok(res)
-    }
-
-    async fn decode_text<R>(
-        src: &mut R,
-        collation: Option<Collation>,
-    ) -> crate::Result<ColumnData<'static>>
-    where
-        R: SqlReadBytes + Unpin,
-    {
-        let ptr_len = src.read_u8().await? as usize;
-
-        if ptr_len == 0 {
-            Ok(ColumnData::String(None))
-        } else {
-            let _ = src.read_exact(&mut vec![0; ptr_len][0..ptr_len]).await?; // text ptr
-
-            src.read_i32_le().await?; // days
-            src.read_u32_le().await?; // second fractions
-
-            let text_len = src.read_u32_le().await? as usize;
-            let mut buf = vec![0; text_len];
-
-            src.read_exact(&mut buf[0..text_len]).await?;
-
-            let collation = collation.as_ref().unwrap();
-            let encoder = collation.encoding()?;
-
-            let text: String = encoder
-                .decode(buf.as_ref(), DecoderTrap::Strict)
-                .map_err(Error::Encoding)?;
-
-            Ok(ColumnData::String(Some(text.into())))
-        }
-    }
-
-    async fn decode_ntext<R>(src: &mut R) -> crate::Result<ColumnData<'static>>
-    where
-        R: SqlReadBytes + Unpin,
-    {
-        let ptr_len = src.read_u8().await? as usize;
-
-        if ptr_len == 0 {
-            Ok(ColumnData::String(None))
-        } else {
-            let _ = src.read_exact(&mut vec![0; ptr_len][0..ptr_len]).await?; // text ptr
-
-            src.read_i32_le().await?; // days
-            src.read_u32_le().await?; // second fractions
-
-            let len = src.read_u32_le().await? as usize / 2;
-            let mut buf = vec![0u16; len];
-
-            for item in buf.iter_mut().take(len) {
-                *item = src.read_u16_le().await?;
-            }
-
-            let text = String::from_utf16(&buf[..])?;
-
-            Ok(ColumnData::String(Some(text.into())))
-        }
-    }
-
-    async fn decode_image<R>(src: &mut R) -> crate::Result<ColumnData<'static>>
-    where
-        R: SqlReadBytes + Unpin,
-    {
-        let ptr_len = src.read_u8().await? as usize;
-
-        if ptr_len == 0 {
-            Ok(ColumnData::Binary(None))
-        } else {
-            let _ = src.read_exact(&mut vec![0; ptr_len][0..ptr_len]).await?; // text ptr
-
-            src.read_i32_le().await?; // days
-            src.read_u32_le().await?; // second fractions
-
-            let len = src.read_u32_le().await? as usize;
-            let mut buf = vec![0; len];
-            src.read_exact(&mut buf[0..len]).await?;
-
-            Ok(ColumnData::Binary(Some(buf.into())))
-        }
-    }
-
-    async fn decode_variable_string<R>(
-        src: &mut R,
-        ty: VarLenType,
-        len: usize,
-        collation: Option<Collation>,
-    ) -> crate::Result<Option<String>>
-    where
-        R: SqlReadBytes + Unpin,
-    {
-        let mode = if ty == VarLenType::NChar || ty == VarLenType::BigChar {
-            ReadTyMode::FixedSize(len)
-        } else {
-            ReadTyMode::auto(len)
-        };
-
-        let data = Self::decode_plp_type(src, mode).await?;
-
-        let res = if let Some(buf) = data {
-            if ty == VarLenType::BigChar {
-                let collation = collation.as_ref().unwrap();
-                let encoder = collation.encoding()?;
-
-                let s: String = encoder
-                    .decode(buf.as_ref(), DecoderTrap::Strict)
-                    .map_err(Error::Encoding)?;
-
-                Some(s)
-            } else {
-                if buf.len() % 2 != 0 {
-                    return Err(Error::Protocol("nvarchar: invalid plp length".into()));
-                }
-
-                let buf: Vec<_> = buf.chunks(2).map(LittleEndian::read_u16).collect();
-                Some(String::from_utf16(&buf)?)
-            }
-        } else {
-            None
-        };
-
-        Ok(res)
-    }
-
-    async fn decode_big_varchar<R>(
-        src: &mut R,
-        len: usize,
-        collation: Option<Collation>,
-    ) -> crate::Result<ColumnData<'static>>
-    where
-        R: SqlReadBytes + Unpin,
-    {
-        let mode = ReadTyMode::auto(len);
-        let data = Self::decode_plp_type(src, mode).await?;
-
-        let res = if let Some(bytes) = data {
-            let collation = collation.as_ref().unwrap();
-            let encoder = collation.encoding()?;
-
-            let s: String = encoder
-                .decode(bytes.as_ref(), DecoderTrap::Strict)
-                .map_err(Error::Encoding)?;
-
-            ColumnData::String(Some(s.into()))
-        } else {
-            ColumnData::String(None)
-        };
-
-        Ok(res)
-    }
-
-    async fn decode_money<R>(src: &mut R, len: u8) -> crate::Result<ColumnData<'static>>
-    where
-        R: SqlReadBytes + Unpin,
-    {
-        let res = match len {
-            0 => ColumnData::F64(None),
-            4 => ColumnData::F64(Some(src.read_i32_le().await? as f64 / 1e4)),
-            8 => ColumnData::F64(Some({
-                let high = src.read_i32_le().await? as i64;
-                let low = src.read_u32_le().await? as f64;
-                ((high << 32) as f64 + low) / 1e4
-            })),
-            _ => {
-                return Err(Error::Protocol(
-                    format!("money: length of {} is invalid", len).into(),
-                ))
-            }
-        };
-
-        Ok(res)
-    }
-
-    async fn decode_binary<R>(src: &mut R, len: usize) -> crate::Result<ColumnData<'static>>
-    where
-        R: SqlReadBytes + Unpin,
-    {
-        let mode = ReadTyMode::auto(len);
-        let data = Self::decode_plp_type(src, mode).await?;
-
-        let res = if let Some(buf) = data {
-            ColumnData::Binary(Some(buf.into()))
-        } else {
-            ColumnData::Binary(None)
-        };
-
-        Ok(res)
-    }
-
-    pub(crate) async fn decode_plp_type<R>(
-        src: &mut R,
-        mode: ReadTyMode,
-    ) -> crate::Result<Option<Vec<u8>>>
-    where
-        R: SqlReadBytes + Unpin,
-    {
-        let mut read_state = ReadTyState::new(mode);
-
-        // If we did not read anything yet, initialize the reader.
-        if read_state.data.is_none() {
-            let size = match read_state.mode {
-                ReadTyMode::FixedSize(_) => src.read_u16_le().await? as u64,
-                ReadTyMode::Plp => src.read_u64_le().await?,
-            };
-
-            read_state.data = match (size, read_state.mode) {
-                (0xffff, ReadTyMode::FixedSize(_)) => None, // NULL value
-                (0xffffffffffffffff, ReadTyMode::Plp) => None, // NULL value
-                (0xfffffffffffffffe, ReadTyMode::Plp) => Some(Vec::new()), // unknown size
-                (len, _) => Some(Vec::with_capacity(len as usize)), // given size
-            };
-
-            // If this is not PLP, treat everything as a single chunk.
-            if let ReadTyMode::FixedSize(_) = read_state.mode {
-                read_state.chunk_data_left = size as usize;
-            }
-        }
-
-        // If there is a buffer, we have something to read.
-        if let Some(ref mut buf) = read_state.data {
-            loop {
-                if read_state.chunk_data_left == 0 {
-                    // We have no chunk. Start a new one.
-                    let chunk_size = match read_state.mode {
-                        ReadTyMode::FixedSize(_) => 0,
-                        ReadTyMode::Plp => src.read_u32_le().await? as usize,
-                    };
-
-                    if chunk_size == 0 {
-                        break; // found a sentinel, we're done
-                    } else {
-                        read_state.chunk_data_left = chunk_size
-                    }
-                } else {
-                    // Just read a byte
-                    let byte = src.read_u8().await?;
-                    read_state.chunk_data_left -= 1;
-
-                    buf.push(byte);
-                }
-            }
-        }
-
-        Ok(read_state.data.take())
     }
 }
 
@@ -736,10 +187,10 @@ impl<'a> Encode<BytesMut> for ColumnData<'a> {
             }
             ColumnData::Guid(Some(uuid)) => {
                 let header = [&[VarLenType::Guid as u8, 16, 16][..]].concat();
-
                 dst.extend_from_slice(&header);
+
                 let mut data = *uuid.as_bytes();
-                guid::reorder_bytes(&mut data);
+                super::guid::reorder_bytes(&mut data);
                 dst.extend_from_slice(&data);
             }
             ColumnData::String(Some(ref s)) if s.len() <= 4000 => {

--- a/src/tds/codec/column_data/binary.rs
+++ b/src/tds/codec/column_data/binary.rs
@@ -1,0 +1,12 @@
+use std::borrow::Cow;
+
+use crate::{sql_read_bytes::SqlReadBytes, ColumnData};
+
+pub(crate) async fn decode<R>(src: &mut R, len: usize) -> crate::Result<ColumnData<'static>>
+where
+    R: SqlReadBytes + Unpin,
+{
+    let data = super::plp::decode(src, len).await?.map(Cow::from);
+
+    Ok(ColumnData::Binary(data))
+}

--- a/src/tds/codec/column_data/bit.rs
+++ b/src/tds/codec/column_data/bit.rs
@@ -1,0 +1,20 @@
+use crate::{error::Error, sql_read_bytes::SqlReadBytes, ColumnData};
+
+pub(crate) async fn decode<R>(src: &mut R) -> crate::Result<ColumnData<'static>>
+where
+    R: SqlReadBytes + Unpin,
+{
+    let recv_len = src.read_u8().await? as usize;
+
+    let res = match recv_len {
+        0 => ColumnData::Bit(None),
+        1 => ColumnData::Bit(Some(src.read_u8().await? > 0)),
+        v => {
+            return Err(Error::Protocol(
+                format!("bitn: length of {} is invalid", v).into(),
+            ))
+        }
+    };
+
+    Ok(res)
+}

--- a/src/tds/codec/column_data/date.rs
+++ b/src/tds/codec/column_data/date.rs
@@ -1,0 +1,22 @@
+use crate::Error;
+
+use crate::{sql_read_bytes::SqlReadBytes, time::Date, ColumnData};
+
+pub(crate) async fn decode<R>(src: &mut R) -> crate::Result<ColumnData<'static>>
+where
+    R: SqlReadBytes + Unpin,
+{
+    let len = src.read_u8().await?;
+
+    let res = match len {
+        0 => ColumnData::Date(None),
+        3 => ColumnData::Date(Some(Date::decode(src).await?)),
+        _ => {
+            return Err(Error::Protocol(
+                format!("daten: length of {} is invalid", len).into(),
+            ))
+        }
+    };
+
+    Ok(res)
+}

--- a/src/tds/codec/column_data/datetime2.rs
+++ b/src/tds/codec/column_data/datetime2.rs
@@ -1,0 +1,18 @@
+use crate::{sql_read_bytes::SqlReadBytes, time::DateTime2, ColumnData};
+
+pub(crate) async fn decode<R>(src: &mut R, len: usize) -> crate::Result<ColumnData<'static>>
+where
+    R: SqlReadBytes + Unpin,
+{
+    let rlen = src.read_u8().await?;
+
+    let date = match rlen {
+        0 => ColumnData::DateTime2(None),
+        rlen => {
+            let dt = DateTime2::decode(src, len, rlen as usize - 3).await?;
+            ColumnData::DateTime2(Some(dt))
+        }
+    };
+
+    Ok(date)
+}

--- a/src/tds/codec/column_data/datetimen.rs
+++ b/src/tds/codec/column_data/datetimen.rs
@@ -1,0 +1,24 @@
+use crate::{
+    error::Error,
+    sql_read_bytes::SqlReadBytes,
+    time::{DateTime, SmallDateTime},
+    ColumnData,
+};
+
+pub(crate) async fn decode<R>(src: &mut R, len: u8) -> crate::Result<ColumnData<'static>>
+where
+    R: SqlReadBytes + Unpin,
+{
+    let datetime = match len {
+        0 => ColumnData::SmallDateTime(None),
+        4 => ColumnData::SmallDateTime(Some(SmallDateTime::decode(src).await?)),
+        8 => ColumnData::DateTime(Some(DateTime::decode(src).await?)),
+        _ => {
+            return Err(Error::Protocol(
+                format!("datetimen: length of {} is invalid", len).into(),
+            ))
+        }
+    };
+
+    Ok(datetime)
+}

--- a/src/tds/codec/column_data/datetimeoffsetn.rs
+++ b/src/tds/codec/column_data/datetimeoffsetn.rs
@@ -1,0 +1,18 @@
+use crate::{sql_read_bytes::SqlReadBytes, time::DateTimeOffset, ColumnData};
+
+pub(crate) async fn decode<R>(src: &mut R, len: usize) -> crate::Result<ColumnData<'static>>
+where
+    R: SqlReadBytes + Unpin,
+{
+    let rlen = src.read_u8().await?;
+
+    let dto = match rlen {
+        0 => ColumnData::DateTimeOffset(None),
+        _ => {
+            let dto = DateTimeOffset::decode(src, len, rlen - 5).await?;
+            ColumnData::DateTimeOffset(Some(dto))
+        }
+    };
+
+    Ok(dto)
+}

--- a/src/tds/codec/column_data/fixed_len.rs
+++ b/src/tds/codec/column_data/fixed_len.rs
@@ -1,0 +1,26 @@
+use crate::{sql_read_bytes::SqlReadBytes, ColumnData, FixedLenType};
+
+pub(crate) async fn decode<R>(
+    src: &mut R,
+    r#type: &FixedLenType,
+) -> crate::Result<ColumnData<'static>>
+where
+    R: SqlReadBytes + Unpin,
+{
+    let data = match r#type {
+        FixedLenType::Null => ColumnData::Bit(None),
+        FixedLenType::Bit => ColumnData::Bit(Some(src.read_u8().await? != 0)),
+        FixedLenType::Int1 => ColumnData::U8(Some(src.read_u8().await?)),
+        FixedLenType::Int2 => ColumnData::I16(Some(src.read_i16_le().await?)),
+        FixedLenType::Int4 => ColumnData::I32(Some(src.read_i32_le().await?)),
+        FixedLenType::Int8 => ColumnData::I64(Some(src.read_i64_le().await?)),
+        FixedLenType::Float4 => ColumnData::F32(Some(src.read_f32_le().await?)),
+        FixedLenType::Float8 => ColumnData::F64(Some(src.read_f64_le().await?)),
+        FixedLenType::Datetime => super::datetimen::decode(src, 8).await?,
+        FixedLenType::Datetime4 => super::datetimen::decode(src, 4).await?,
+        FixedLenType::Money4 => super::money::decode(src, 4).await?,
+        FixedLenType::Money => super::money::decode(src, 8).await?,
+    };
+
+    Ok(data)
+}

--- a/src/tds/codec/column_data/float.rs
+++ b/src/tds/codec/column_data/float.rs
@@ -1,0 +1,21 @@
+use crate::{error::Error, sql_read_bytes::SqlReadBytes, ColumnData};
+
+pub(crate) async fn decode<R>(src: &mut R) -> crate::Result<ColumnData<'static>>
+where
+    R: SqlReadBytes + Unpin,
+{
+    let len = src.read_u8().await? as usize;
+
+    let res = match len {
+        0 => ColumnData::F32(None),
+        4 => ColumnData::F32(Some(src.read_f32_le().await?)),
+        8 => ColumnData::F64(Some(src.read_f64_le().await?)),
+        _ => {
+            return Err(Error::Protocol(
+                format!("floatn: length of {} is invalid", len).into(),
+            ))
+        }
+    };
+
+    Ok(res)
+}

--- a/src/tds/codec/column_data/guid.rs
+++ b/src/tds/codec/column_data/guid.rs
@@ -1,0 +1,31 @@
+use uuid::Uuid;
+
+use crate::{error::Error, sql_read_bytes::SqlReadBytes, tds::codec::guid, ColumnData};
+
+pub(crate) async fn decode<R>(src: &mut R) -> crate::Result<ColumnData<'static>>
+where
+    R: SqlReadBytes + Unpin,
+{
+    let len = src.read_u8().await? as usize;
+
+    let res = match len {
+        0 => ColumnData::Guid(None),
+        16 => {
+            let mut data = [0u8; 16];
+
+            for item in &mut data {
+                *item = src.read_u8().await?;
+            }
+
+            guid::reorder_bytes(&mut data);
+            ColumnData::Guid(Some(Uuid::from_bytes(data)))
+        }
+        _ => {
+            return Err(Error::Protocol(
+                format!("guid: length of {} is invalid", len).into(),
+            ))
+        }
+    };
+
+    Ok(res)
+}

--- a/src/tds/codec/column_data/image.rs
+++ b/src/tds/codec/column_data/image.rs
@@ -1,0 +1,28 @@
+use crate::{sql_read_bytes::SqlReadBytes, ColumnData};
+
+pub(crate) async fn decode<R>(src: &mut R) -> crate::Result<ColumnData<'static>>
+where
+    R: SqlReadBytes + Unpin,
+{
+    let ptr_len = src.read_u8().await? as usize;
+
+    if ptr_len == 0 {
+        return Ok(ColumnData::Binary(None));
+    }
+
+    for _ in 0..ptr_len {
+        src.read_u8().await?;
+    }
+
+    src.read_i32_le().await?; // days
+    src.read_u32_le().await?; // second fractions
+
+    let len = src.read_u32_le().await? as usize;
+    let mut buf = Vec::with_capacity(len);
+
+    for _ in 0..len {
+        buf.push(src.read_u8().await?);
+    }
+
+    Ok(ColumnData::Binary(Some(buf.into())))
+}

--- a/src/tds/codec/column_data/int.rs
+++ b/src/tds/codec/column_data/int.rs
@@ -1,0 +1,19 @@
+use crate::{sql_read_bytes::SqlReadBytes, ColumnData};
+
+pub(crate) async fn decode<R>(src: &mut R) -> crate::Result<ColumnData<'static>>
+where
+    R: SqlReadBytes + Unpin,
+{
+    let recv_len = src.read_u8().await? as usize;
+
+    let res = match recv_len {
+        0 => ColumnData::U8(None),
+        1 => ColumnData::U8(Some(src.read_u8().await?)),
+        2 => ColumnData::I16(Some(src.read_i16_le().await?)),
+        4 => ColumnData::I32(Some(src.read_i32_le().await?)),
+        8 => ColumnData::I64(Some(src.read_i64_le().await?)),
+        _ => unimplemented!(),
+    };
+
+    Ok(res)
+}

--- a/src/tds/codec/column_data/money.rs
+++ b/src/tds/codec/column_data/money.rs
@@ -1,0 +1,24 @@
+use crate::{error::Error, sql_read_bytes::SqlReadBytes, ColumnData};
+
+pub(crate) async fn decode<R>(src: &mut R, len: u8) -> crate::Result<ColumnData<'static>>
+where
+    R: SqlReadBytes + Unpin,
+{
+    let res = match len {
+        0 => ColumnData::F64(None),
+        4 => ColumnData::F64(Some(src.read_i32_le().await? as f64 / 1e4)),
+        8 => ColumnData::F64(Some({
+            let high = src.read_i32_le().await? as i64;
+            let low = src.read_u32_le().await? as f64;
+
+            ((high << 32) as f64 + low) / 1e4
+        })),
+        _ => {
+            return Err(Error::Protocol(
+                format!("money: length of {} is invalid", len).into(),
+            ))
+        }
+    };
+
+    Ok(res)
+}

--- a/src/tds/codec/column_data/plp.rs
+++ b/src/tds/codec/column_data/plp.rs
@@ -1,0 +1,64 @@
+use crate::sql_read_bytes::SqlReadBytes;
+
+// Decode a partially length-prefixed type.
+pub(crate) async fn decode<R>(src: &mut R, len: usize) -> crate::Result<Option<Vec<u8>>>
+where
+    R: SqlReadBytes + Unpin,
+{
+    match len {
+        // Fixed size
+        len if len < 0xffff => {
+            let len = src.read_u16_le().await? as u64;
+
+            match len {
+                // NULL
+                0xffff => Ok(None),
+                _ => {
+                    let mut data = Vec::with_capacity(len as usize);
+
+                    for _ in 0..len {
+                        data.push(src.read_u8().await?);
+                    }
+
+                    Ok(Some(data))
+                }
+            }
+        }
+        // Unknown size, length-prefixed blobs
+        _ => {
+            let len = src.read_u64_le().await?;
+
+            let mut data = match len {
+                // NULL
+                0xffffffffffffffff => return Ok(None),
+                // Unknown size
+                0xfffffffffffffffe => Vec::new(),
+                // Known size
+                _ => Vec::with_capacity(len as usize),
+            };
+
+            let mut chunk_data_left = 0;
+
+            loop {
+                if chunk_data_left == 0 {
+                    // We have no chunk. Start a new one.
+                    let chunk_size = src.read_u32_le().await? as usize;
+
+                    if chunk_size == 0 {
+                        break; // found a sentinel, we're done
+                    } else {
+                        chunk_data_left = chunk_size
+                    }
+                } else {
+                    // Just read a byte
+                    let byte = src.read_u8().await?;
+                    chunk_data_left -= 1;
+
+                    data.push(byte);
+                }
+            }
+
+            Ok(Some(data))
+        }
+    }
+}

--- a/src/tds/codec/column_data/string.rs
+++ b/src/tds/codec/column_data/string.rs
@@ -1,0 +1,44 @@
+use std::borrow::Cow;
+
+use byteorder::{ByteOrder, LittleEndian};
+use encoding::DecoderTrap;
+
+use crate::{error::Error, sql_read_bytes::SqlReadBytes, tds::Collation, VarLenType};
+
+pub(crate) async fn decode<R>(
+    src: &mut R,
+    ty: VarLenType,
+    len: usize,
+    collation: Option<Collation>,
+) -> crate::Result<Option<Cow<'static, str>>>
+where
+    R: SqlReadBytes + Unpin,
+{
+    use VarLenType::*;
+
+    let data = super::plp::decode(src, len).await?;
+
+    match (data, ty) {
+        // Codepages other than UTF
+        (Some(buf), BigChar) | (Some(buf), BigVarChar) => {
+            let collation = collation.as_ref().unwrap();
+            let encoder = collation.encoding()?;
+
+            let s: String = encoder
+                .decode(buf.as_ref(), DecoderTrap::Strict)
+                .map_err(Error::Encoding)?;
+
+            Ok(Some(s.into()))
+        }
+        // UTF-16
+        (Some(buf), _) => {
+            if buf.len() % 2 != 0 {
+                return Err(Error::Protocol("nvarchar: invalid plp length".into()));
+            }
+
+            let buf: Vec<_> = buf.chunks(2).map(LittleEndian::read_u16).collect();
+            Ok(Some(String::from_utf16(&buf)?.into()))
+        }
+        _ => Ok(None),
+    }
+}

--- a/src/tds/codec/column_data/text.rs
+++ b/src/tds/codec/column_data/text.rs
@@ -1,0 +1,54 @@
+use encoding::DecoderTrap;
+
+use crate::{error::Error, sql_read_bytes::SqlReadBytes, tds::Collation, ColumnData};
+
+pub(crate) async fn decode<R>(
+    src: &mut R,
+    collation: Option<Collation>,
+) -> crate::Result<ColumnData<'static>>
+where
+    R: SqlReadBytes + Unpin,
+{
+    let ptr_len = src.read_u8().await? as usize;
+
+    if ptr_len == 0 {
+        return Ok(ColumnData::String(None));
+    }
+
+    for _ in 0..ptr_len {
+        src.read_u8().await?;
+    }
+
+    src.read_i32_le().await?; // days
+    src.read_u32_le().await?; // second fractions
+
+    let text = match collation {
+        // TEXT
+        Some(collation) => {
+            let encoder = collation.encoding()?;
+            let text_len = src.read_u32_le().await? as usize;
+            let mut buf = Vec::with_capacity(text_len);
+
+            for _ in 0..text_len {
+                buf.push(src.read_u8().await?);
+            }
+
+            encoder
+                .decode(buf.as_ref(), DecoderTrap::Strict)
+                .map_err(Error::Encoding)?
+        }
+        // NTEXT
+        None => {
+            let text_len = src.read_u32_le().await? as usize / 2;
+            let mut buf = Vec::with_capacity(text_len);
+
+            for _ in 0..text_len {
+                buf.push(src.read_u16_le().await?);
+            }
+
+            String::from_utf16(&buf[..])?
+        }
+    };
+
+    Ok(ColumnData::String(Some(text.into())))
+}

--- a/src/tds/codec/column_data/time.rs
+++ b/src/tds/codec/column_data/time.rs
@@ -1,0 +1,18 @@
+use crate::{sql_read_bytes::SqlReadBytes, time::Time, ColumnData};
+
+pub(crate) async fn decode<R>(src: &mut R, len: usize) -> crate::Result<ColumnData<'static>>
+where
+    R: SqlReadBytes + Unpin,
+{
+    let rlen = src.read_u8().await?;
+
+    let time = match rlen {
+        0 => ColumnData::Time(None),
+        _ => {
+            let time = Time::decode(src, len as usize, rlen as usize).await?;
+            ColumnData::Time(Some(time))
+        }
+    };
+
+    Ok(time)
+}

--- a/src/tds/codec/column_data/var_len.rs
+++ b/src/tds/codec/column_data/var_len.rs
@@ -1,0 +1,48 @@
+use crate::{sql_read_bytes::SqlReadBytes, tds::codec::VarLenContext, ColumnData, VarLenType};
+
+pub(crate) async fn decode<R>(
+    src: &mut R,
+    ctx: &VarLenContext,
+) -> crate::Result<ColumnData<'static>>
+where
+    R: SqlReadBytes + Unpin,
+{
+    use VarLenType::*;
+
+    let ty = ctx.r#type();
+    let len = ctx.len();
+    let collation = ctx.collation();
+
+    let res = match ty {
+        Bitn => super::bit::decode(src).await?,
+        Intn => super::int::decode(src).await?,
+        Floatn => super::float::decode(src).await?,
+        Guid => super::guid::decode(src).await?,
+        BigChar | BigVarChar | NChar | NVarchar => {
+            ColumnData::String(super::string::decode(src, ty, len, collation).await?)
+        }
+        Money => {
+            let len = src.read_u8().await?;
+            super::money::decode(src, len).await?
+        }
+        Datetimen => {
+            let len = src.read_u8().await?;
+            super::datetimen::decode(src, len).await?
+        }
+        #[cfg(feature = "tds73")]
+        Daten => super::date::decode(src).await?,
+        #[cfg(feature = "tds73")]
+        Timen => super::time::decode(src, len).await?,
+        #[cfg(feature = "tds73")]
+        Datetime2 => super::datetime2::decode(src, len as usize).await?,
+        #[cfg(feature = "tds73")]
+        DatetimeOffsetn => super::datetimeoffsetn::decode(src, len as usize).await?,
+        BigBinary | BigVarBin => super::binary::decode(src, len).await?,
+        Text => super::text::decode(src, collation).await?,
+        NText => super::text::decode(src, None).await?,
+        Image => super::image::decode(src).await?,
+        t => unimplemented!("{:?}", t),
+    };
+
+    Ok(res)
+}

--- a/src/tds/codec/column_data/xml.rs
+++ b/src/tds/codec/column_data/xml.rs
@@ -1,0 +1,30 @@
+use std::{borrow::Cow, sync::Arc};
+
+use crate::{
+    sql_read_bytes::SqlReadBytes,
+    xml::{XmlData, XmlSchema},
+    ColumnData, VarLenType,
+};
+
+pub(crate) async fn decode<R>(
+    src: &mut R,
+    len: usize,
+    schema: Option<Arc<XmlSchema>>,
+) -> crate::Result<ColumnData<'static>>
+where
+    R: SqlReadBytes + Unpin,
+{
+    let xml = super::string::decode(src, VarLenType::Xml, len, None)
+        .await?
+        .map(|data| {
+            let mut data = XmlData::new(data);
+
+            if let Some(schema) = schema {
+                data.set_schema(schema);
+            }
+
+            Cow::Owned(data)
+        });
+
+    Ok(ColumnData::Xml(xml))
+}

--- a/src/tds/codec/type_info.rs
+++ b/src/tds/codec/type_info.rs
@@ -4,7 +4,7 @@ use std::{convert::TryFrom, sync::Arc};
 #[derive(Debug)]
 pub enum TypeInfo {
     FixedLen(FixedLenType),
-    VarLenSized(VarLenType, usize, Option<Collation>),
+    VarLenSized(VarLenContext),
     VarLenSizedPrecision {
         ty: VarLenType,
         size: usize,
@@ -15,6 +15,38 @@ pub enum TypeInfo {
         schema: Option<Arc<XmlSchema>>,
         size: usize,
     },
+}
+
+#[derive(Clone, Debug, Copy)]
+pub struct VarLenContext {
+    r#type: VarLenType,
+    len: usize,
+    collation: Option<Collation>,
+}
+
+impl VarLenContext {
+    pub fn new(r#type: VarLenType, len: usize, collation: Option<Collation>) -> Self {
+        Self {
+            r#type,
+            len,
+            collation,
+        }
+    }
+
+    /// Get the var len context's r#type.
+    pub fn r#type(&self) -> VarLenType {
+        self.r#type
+    }
+
+    /// Get the var len context's len.
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Get the var len context's collation.
+    pub fn collation(&self) -> Option<Collation> {
+        self.collation
+    }
 }
 
 uint_enum! {
@@ -201,7 +233,10 @@ impl TypeInfo {
                             scale,
                         }
                     }
-                    _ => TypeInfo::VarLenSized(ty, len, collation),
+                    _ => {
+                        let cx = VarLenContext::new(ty, len, collation);
+                        TypeInfo::VarLenSized(cx)
+                    }
                 };
 
                 Ok(vty)


### PR DESCRIPTION
- Some repetition removed.
- The monster `column_data.rs` is now split.
- PLP decoding simplified, like a lot
- TEXT and NTEXT column handling should be faster, we don't initialize a vector of zeroes before reading the data!