### PR TITLE
Allow setting application name per connection

### DIFF
--- a/src/client/config.rs
+++ b/src/client/config.rs
@@ -26,6 +26,7 @@ pub struct Config {
     pub(crate) port: Option<u16>,
     pub(crate) database: Option<String>,
     pub(crate) instance_name: Option<String>,
+    pub(crate) application_name: Option<String>,
     pub(crate) encryption: EncryptionLevel,
     pub(crate) trust_cert: bool,
     pub(crate) auth: AuthMethod,
@@ -38,6 +39,7 @@ impl Default for Config {
             port: None,
             database: None,
             instance_name: None,
+            application_name: None,
             encryption: EncryptionLevel::Required,
             trust_cert: false,
             auth: AuthMethod::None,
@@ -81,6 +83,14 @@ impl Config {
     /// - Defaults to no name specified.
     pub fn instance_name(&mut self, name: impl ToString) {
         self.instance_name = Some(name.to_string());
+    }
+
+    /// Sets the application name to the connection, queryable with the
+    /// `APP_NAME()` command.
+    ///
+    /// - Defaults to no name specified.
+    pub fn application_name(&mut self, name: impl ToString) {
+        self.application_name = Some(name.to_string());
     }
 
     /// Set the preferred encryption level.
@@ -148,6 +158,7 @@ impl Config {
     /// |`database`|`<string>`|The name of the database.|
     /// |`TrustServerCertificate`|`true`,`false`,`yes`,`no`|Specifies whether the driver trusts the server certificate when connecting using TLS.|
     /// |`encrypt`|`true`,`false`,`yes`,`no`,`DANGER_PLAINTEXT`|Specifies whether the driver uses TLS to encrypt communication.|
+    /// |`Application Name`, `ApplicationName`|`<string>`|Sets the application name for the connection.|
     ///
     /// [ADO.NET connection string]: https://docs.microsoft.com/en-us/dotnet/framework/data/adonet/connection-strings
     pub fn from_ado_string(s: &str) -> crate::Result<Self> {
@@ -187,6 +198,10 @@ impl Config {
 
         if let Some(database) = s.database() {
             builder.database(database);
+        }
+
+        if let Some(name) = s.application_name() {
+            builder.application_name(name);
         }
 
         if s.trust_cert()? {
@@ -250,6 +265,13 @@ pub(crate) trait ConfigString {
             .or_else(|| self.dict().get("initial catalog"))
             .or_else(|| self.dict().get("databasename"))
             .map(|db| db.to_string())
+    }
+
+    fn application_name(&self) -> Option<String> {
+        self.dict()
+            .get("application name")
+            .or_else(|| self.dict().get("applicationname"))
+            .map(|name| name.to_string())
     }
 
     fn trust_cert(&self) -> crate::Result<bool> {

--- a/src/client/config/ado_net.rs
+++ b/src/client/config/ado_net.rs
@@ -391,4 +391,19 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn application_name_parsing() -> crate::Result<()> {
+        let test_str = "Application Name=meow";
+        let ado: AdoNetConfig = test_str.parse()?;
+
+        assert_eq!(Some("meow".into()), ado.application_name());
+
+        let test_str = "ApplicationName=meow";
+        let ado: AdoNetConfig = test_str.parse()?;
+
+        assert_eq!(Some("meow".into()), ado.application_name());
+
+        Ok(())
+    }
 }

--- a/src/client/config/jdbc.rs
+++ b/src/client/config/jdbc.rs
@@ -282,4 +282,19 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn application_name_parsing() -> crate::Result<()> {
+        let test_str = "jdbc:sqlserver://my-server.com:4200;Application Name=meow";
+        let jdbc: JdbcConfig = test_str.parse()?;
+
+        assert_eq!(Some("meow".into()), jdbc.application_name());
+
+        let test_str = "jdbc:sqlserver://my-server.com:4200;ApplicationName=meow";
+        let jdbc: JdbcConfig = test_str.parse()?;
+
+        assert_eq!(Some("meow".into()), jdbc.application_name());
+
+        Ok(())
+    }
 }

--- a/src/client/connection.rs
+++ b/src/client/connection.rs
@@ -94,7 +94,13 @@ impl<S: AsyncRead + AsyncWrite + Unpin + Send> Connection<S> {
             .await?;
 
         let mut connection = connection
-            .login(config.auth, encryption, config.database, config.host)
+            .login(
+                config.auth,
+                encryption,
+                config.database,
+                config.host,
+                config.application_name,
+            )
             .await?;
 
         connection.flush_done().await?;
@@ -233,6 +239,7 @@ impl<S: AsyncRead + AsyncWrite + Unpin + Send> Connection<S> {
         encryption: EncryptionLevel,
         db: Option<String>,
         server_name: Option<String>,
+        application_name: Option<String>,
     ) -> crate::Result<Self> {
         let mut login_message = LoginMessage::new();
 
@@ -242,6 +249,10 @@ impl<S: AsyncRead + AsyncWrite + Unpin + Send> Connection<S> {
 
         if let Some(server_name) = server_name {
             login_message.server_name(server_name);
+        }
+
+        if let Some(app_name) = application_name {
+            login_message.app_name(app_name);
         }
 
         match auth {

--- a/src/tds/codec/login.rs
+++ b/src/tds/codec/login.rs
@@ -182,6 +182,10 @@ impl<'a> LoginMessage<'a> {
         self.integrated_security = bytes;
     }
 
+    pub fn app_name(&mut self, name: impl Into<Cow<'a, str>>) {
+        self.app_name = name.into();
+    }
+
     pub fn db_name(&mut self, db_name: impl Into<Cow<'a, str>>) {
         self.db_name = db_name.into();
     }


### PR DESCRIPTION
Available from Config method `application_name` and in the JDBC and ADO.net strings either with `Application Name` or
`ApplicationName` (case-insensitive).

Closes: https://github.com/prisma/tiberius/issues/159