### PR TITLE
Update bigint to 0.4.0 to fix build errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ optional = true
 package = "bigdecimal"
 
 [dependencies.num-bigint]
-version = "0.3.0"
+version = "0.4.0"
 default-features = false
 optional = true
 features = ["std"]

--- a/src/tds/codec/token/token_col_metadata.rs
+++ b/src/tds/codec/token/token_col_metadata.rs
@@ -161,7 +161,7 @@ impl TokenColMetaData {
         Ok(TokenColMetaData { columns })
     }
 
-    pub(crate) fn columns<'a>(&'a self) -> impl Iterator<Item = Column> + 'a {
+    pub(crate) fn columns(&self) -> impl Iterator<Item = Column> + '_ {
         self.columns.iter().map(|x| Column {
             name: x.col_name.clone(),
             column_type: ColumnType::from(&x.base.ty),

--- a/src/tds/stream/query.rs
+++ b/src/tds/stream/query.rs
@@ -228,11 +228,7 @@ impl<'a> QueryStream<'a> {
         while let Some(item) = self.try_next().await? {
             match (item, &mut result) {
                 (QueryItem::Row(row), None) => {
-                    result.insert({
-                        let mut result = Vec::new();
-                        result.push(row);
-                        result
-                    });
+                    result.insert(vec![row]);
                 }
                 (QueryItem::Row(row), Some(ref mut result)) => result.push(row),
                 (QueryItem::Metadata(_), None) => {


### PR DESCRIPTION
Thanks to bigdecimal updating their bigint, the crates are not compatible between versions and this update bubbled in to our codebase, preventing compilation.

Part of: https://github.com/prisma/prisma-engines/pull/2186