### PR TITLE
fix: use bundled bigint from bigdecimal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,12 +107,6 @@ version = "0.2.0"
 optional = true
 package = "bigdecimal"
 
-[dependencies.num-bigint]
-version = "0.4.0"
-default-features = false
-optional = true
-features = ["std"]
-
 [dependencies.async-io]
 version = "1.4.1"
 optional = true
@@ -167,4 +161,4 @@ sql-browser-async-std = ["async-std"]
 sql-browser-tokio = ["tokio", "tokio-util"]
 sql-browser-smol = ["async-io", "async-net", "futures-lite"]
 integrated-auth-gssapi = ["libgssapi"]
-bigdecimal = [ "bigdecimal_", "num-bigint" ]
+bigdecimal = [ "bigdecimal_"]

--- a/src/tds/numeric.rs
+++ b/src/tds/numeric.rs
@@ -4,12 +4,9 @@ use super::codec::Encode;
 use crate::{sql_read_bytes::SqlReadBytes, Error};
 #[cfg(feature = "bigdecimal")]
 #[cfg_attr(feature = "docs", doc(cfg(feature = "bigdecimal")))]
-pub use bigdecimal::BigDecimal;
+pub use bigdecimal::{num_bigint::BigInt, BigDecimal};
 use byteorder::{ByteOrder, LittleEndian};
 use bytes::{BufMut, BytesMut};
-#[cfg(feature = "bigdecimal")]
-#[cfg_attr(feature = "docs", doc(cfg(feature = "bigdecimal")))]
-pub use num_bigint::{BigInt, Sign};
 #[cfg(feature = "rust_decimal")]
 #[cfg_attr(feature = "docs", doc(cfg(feature = "rust_decimal")))]
 pub use rust_decimal::Decimal;

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -1461,7 +1461,7 @@ mod bigdecimal {
     where
         S: AsyncRead + AsyncWrite + Unpin + Send,
     {
-        use num_bigint::BigInt;
+        use bigdecimal_::num_bigint::BigInt;
         use num_traits::FromPrimitive;
         use tiberius::numeric::BigDecimal;
 
@@ -1485,7 +1485,7 @@ mod bigdecimal {
     where
         S: AsyncRead + AsyncWrite + Unpin + Send,
     {
-        use num_bigint::BigInt;
+        use bigdecimal_::num_bigint::BigInt;
         use num_traits::FromPrimitive;
         use tiberius::numeric::BigDecimal;
 
@@ -1509,7 +1509,7 @@ mod bigdecimal {
     where
         S: AsyncRead + AsyncWrite + Unpin + Send,
     {
-        use num_bigint::BigInt;
+        use bigdecimal_::num_bigint::BigInt;
         use num_traits::FromPrimitive;
         use tiberius::numeric::BigDecimal;
 


### PR DESCRIPTION
## Overview

Fixes a dependency version conflict on Quaint by using the bundled and exposed version of `num_bigint` by `bigdecimal`.