### PR TITLE
Optionalize winauth dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ num-traits = "0.2"
 uuid = "0.8"
 
 [target.'cfg(windows)'.dependencies]
-winauth = "0.0.4"
+winauth = { version = "0.0.4", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libgssapi = { version = "0.4.5", optional = true, default-features = false }
@@ -154,7 +154,7 @@ all = [
     "rust_decimal",
     "bigdecimal"
 ]
-default = ["tds73"]
+default = ["tds73", "winauth"]
 vendored-openssl = ["opentls/vendored", "async-native-tls/vendored"]
 tds73 = []
 docs = []

--- a/src/client/auth.rs
+++ b/src/client/auth.rs
@@ -26,16 +26,16 @@ impl Debug for SqlServerAuth {
 }
 
 #[derive(Clone, PartialEq)]
-#[cfg(any(windows, doc))]
-#[cfg_attr(feature = "docs", doc(windows))]
+#[cfg(any(all(windows, feature = "winauth"), doc))]
+#[cfg_attr(feature = "docs", doc(all(windows, feature = "winauth")))]
 pub struct WindowsAuth {
     pub(crate) user: String,
     pub(crate) password: String,
     pub(crate) domain: Option<String>,
 }
 
-#[cfg(any(windows, doc))]
-#[cfg_attr(feature = "docs", doc(windows))]
+#[cfg(any(all(windows, feature = "winauth"), doc))]
+#[cfg_attr(feature = "docs", doc(all(windows, feature = "winauth")))]
 impl Debug for WindowsAuth {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("WindowsAuth")
@@ -52,8 +52,8 @@ pub enum AuthMethod {
     /// Authenticate directly with SQL Server.
     SqlServer(SqlServerAuth),
     /// Authenticate with Windows credentials.
-    #[cfg(any(windows, doc))]
-    #[cfg_attr(feature = "docs", doc(cfg(windows)))]
+    #[cfg(any(all(windows, feature = "winauth"), doc))]
+    #[cfg_attr(feature = "docs", doc(cfg(all(windows, feature = "winauth"))))]
     Windows(WindowsAuth),
     /// Authenticate as the currently logged in user. On Windows uses SSPI and
     /// Kerberos on Unix platforms.
@@ -77,8 +77,8 @@ impl AuthMethod {
     }
 
     /// Construct a new Windows authentication configuration.
-    #[cfg(any(windows, doc))]
-    #[cfg_attr(feature = "docs", doc(cfg(windows)))]
+    #[cfg(any(all(windows, feature = "winauth"), doc))]
+    #[cfg_attr(feature = "docs", doc(cfg(all(windows, feature = "winauth"))))]
     pub fn windows(user: impl AsRef<str>, password: impl ToString) -> Self {
         let (domain, user) = match user.as_ref().find('\\') {
             Some(idx) => (Some(&user.as_ref()[..idx]), &user.as_ref()[idx + 1..]),

--- a/src/client/connection.rs
+++ b/src/client/connection.rs
@@ -35,7 +35,7 @@ use std::ops::Deref;
 use std::{cmp, fmt::Debug, io, pin::Pin, task};
 use task::Poll;
 use tracing::{event, Level};
-#[cfg(windows)]
+#[cfg(all(windows, feature = "winauth"))]
 use winauth::{windows::NtlmSspiBuilder, NextBytes};
 
 /// A `Connection` is an abstraction between the [`Client`] and the server. It
@@ -325,7 +325,7 @@ impl<S: AsyncRead + AsyncWrite + Unpin + Send> Connection<S> {
 
                 self.send(header, next_token).await?;
             }
-            #[cfg(windows)]
+            #[cfg(all(windows, feature = "winauth"))]
             AuthMethod::Windows(auth) => {
                 let spn = self.context.spn().to_string();
                 let builder = winauth::NtlmV2ClientBuilder::new().target_spn(spn);


### PR DESCRIPTION
@pimeys this is a bit less of a slam dunk than my last PR, but hoping you might still consider it! I left the `winauth` feature enabled by default, so that most users won't even notice this change.

----

The winauth dependency is looking increasingly unmaintained; its
dependencies haven't been updated in several years. Optionalize the
feature, so that users who don't need the winauth support don't get
stuck with old versions of md5 and rand in their tree.