### PR TITLE
Prepare renaming of main branch from master to main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,6 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
-            toolchain: nightly
             components: clippy
             override: true
       - name: Install dependencies
@@ -28,7 +27,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
           components: rustfmt
           override: true
       - uses: mbrobbel/rustfmt-check@master
@@ -44,8 +42,6 @@ jobs:
         database:
           - 2017
           - 2019
-        rust:
-          - stable
         features:
           - "--features=all"
           - "--no-default-features --features=chrono"
@@ -58,8 +54,6 @@ jobs:
       - uses: actions/checkout@v2
 
       - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{matrix.rust}}
 
       - uses: actions/cache@v2
         with:
@@ -86,8 +80,6 @@ jobs:
       matrix:
         database:
           - 2019
-        rust:
-          - stable
         features:
           - "--features=all"
 
@@ -99,8 +91,6 @@ jobs:
       - uses: actions/checkout@v2
 
       - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
 
       - name: Set required PowerShell modules
         id: psmodulecache
@@ -198,8 +188,6 @@ jobs:
       matrix:
         database:
           - 2019
-        rust:
-          - stable
         features:
           - "--features=all,vendored-openssl"
 
@@ -210,8 +198,6 @@ jobs:
       - uses: actions/checkout@v2
 
       - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{matrix.rust}}
 
       - uses: docker-practice/actions-setup-docker@master
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Cargo tests
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 jobs:
   clippy:

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.56.0"
+profile = "default"

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,1 @@
-[toolchain]
-channel = "1.56.0"
-profile = "default"
+1.56.0


### PR DESCRIPTION
- Rename `master` to `main`
- Add `rust-toolchain` file for (more) reproducible builds with a pinned Rust version
- Remove `toolchain` from GH Actions so value from `rust-toolchain` is used instead
- Remove GH Actions matrixes for toolchain version as unused and to enable picking up from `rust-toolchain` as well