### PR TITLE
Remove unused async-stream dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,6 @@ name = "named-instance-smol"
 required-features = ["sql-browser-smol"]
 
 [dependencies]
-async-stream = "0.2"
 enumflags2 = "0.7"
 byteorder = "1.0"
 encoding = "0.2"


### PR DESCRIPTION
`git grep async_stream` returns no matches.