### PR TITLE
Remove async-std from deps if using tokio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ libgssapi = { version = "0.4.5", optional = true, default-features = false }
 opentls = { version = "0.2.1", features = ["io-async-std"]}
 
 [target.'cfg(not(any(target_os = "macos", target_os = "ios")))'.dependencies]
-async-native-tls = { version = "0.3", features = ["runtime-async-std"]}
+async-native-tls = { version = "0.4", features = ["runtime-async-std"] }
 
 [dependencies.tokio]
 version = "1.0"

--- a/src/tds/codec/token/token_done.rs
+++ b/src/tds/codec/token/token_done.rs
@@ -2,6 +2,7 @@ use crate::{Error, SqlReadBytes};
 use enumflags2::{bitflags, BitFlags};
 use std::fmt;
 
+#[allow(dead_code)] // we might want to debug the values
 #[derive(Debug)]
 pub struct TokenDone {
     status: BitFlags<DoneStatus>,

--- a/src/tds/codec/token/token_info.rs
+++ b/src/tds/codec/token/token_info.rs
@@ -1,5 +1,6 @@
 use crate::SqlReadBytes;
 
+#[allow(dead_code)] // we might want to debug the values
 #[derive(Debug)]
 pub struct TokenInfo {
     /// info number

--- a/src/tds/codec/token/token_login_ack.rs
+++ b/src/tds/codec/token/token_login_ack.rs
@@ -1,6 +1,7 @@
 use crate::{Error, FeatureLevel, SqlReadBytes};
 use std::convert::TryFrom;
 
+#[allow(dead_code)] // we might want to debug the values
 #[derive(Debug)]
 pub struct TokenLoginAck {
     /// The type of interface with which the server will accept client requests

--- a/src/tds/codec/token/token_order.rs
+++ b/src/tds/codec/token/token_order.rs
@@ -1,5 +1,6 @@
 use crate::SqlReadBytes;
 
+#[allow(dead_code)] // we might want to debug the values
 #[derive(Debug)]
 pub struct TokenOrder {
     pub(crate) column_indexes: Vec<u16>,


### PR DESCRIPTION
The 0.4 version of async-native-tls just uses `futures-util` instead of `async-std`, allowing us to get rid of `async-std` if using tokio runtime.

https://github.com/async-email/async-native-tls/blob/master/Cargo.toml#L30

Helps with: https://github.com/prisma/prisma-engines/pull/2562