### PR TITLE
Add missing winauth feature gates

### DIFF
--- a/src/client/auth.rs
+++ b/src/client/auth.rs
@@ -57,7 +57,11 @@ pub enum AuthMethod {
     Windows(WindowsAuth),
     /// Authenticate as the currently logged in user. On Windows uses SSPI and
     /// Kerberos on Unix platforms.
-    #[cfg(any(windows, all(unix, feature = "integrated-auth-gssapi"), doc))]
+    #[cfg(any(
+        all(windows, feature = "winauth"),
+        all(unix, feature = "integrated-auth-gssapi"),
+        doc
+    ))]
     #[cfg_attr(
         feature = "docs",
         doc(cfg(any(windows, all(unix, feature = "integrated-auth-gssapi"))))

--- a/src/client/config.rs
+++ b/src/client/config.rs
@@ -245,7 +245,7 @@ pub(crate) trait ConfigString {
             .get("integratedsecurity")
             .or_else(|| self.dict().get("integrated security"))
         {
-            #[cfg(windows)]
+            #[cfg(all(windows, feature = "winauth"))]
             Some(val) if val.to_lowercase() == "sspi" || Self::parse_bool(val)? => match (user, pw)
             {
                 (None, None) => Ok(AuthMethod::Integrated),

--- a/src/client/connection.rs
+++ b/src/client/connection.rs
@@ -256,7 +256,7 @@ impl<S: AsyncRead + AsyncWrite + Unpin + Send> Connection<S> {
         }
 
         match auth {
-            #[cfg(windows)]
+            #[cfg(all(windows, feature = "winauth"))]
             AuthMethod::Integrated => {
                 let mut client = NtlmSspiBuilder::new()
                     .target_spn(self.context.spn())


### PR DESCRIPTION
Currently, building without default features fails on windows because
there are feature gated includes used in non-gated code that were missed
in a8ae150c4988366f3f96ad4755db3b5a3d70a95c.