### PR TITLE
Dynamic query interface

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -77,15 +77,15 @@ macro_rules! to_sql {
 macro_rules! into_sql {
     ($target:ident, $( $ty:ty: ($variant:expr, $val:expr) ;)* ) => {
         $(
-            impl crate::IntoSql for $ty {
-                fn into_sql(self) -> crate::tds::codec::ColumnData<'static> {
+            impl<'a> crate::IntoSql<'a> for $ty {
+                fn into_sql(self) -> crate::tds::codec::ColumnData<'a> {
                     let $target = self;
                     $variant(Some($val))
                 }
             }
 
-            impl crate::IntoSql for Option<$ty> {
-                fn into_sql(self) -> crate::tds::codec::ColumnData<'static> {
+            impl<'a> crate::IntoSql<'a> for Option<$ty> {
+                fn into_sql(self) -> crate::tds::codec::ColumnData<'a> {
                     match self {
                         Some(val) => {
                             let $target = val;

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,0 +1,138 @@
+use std::borrow::Cow;
+
+use futures::{AsyncRead, AsyncWrite};
+
+use crate::{
+    tds::{codec::RpcProcId, stream::TokenStream},
+    Client, ColumnData, ExecuteResult, IntoSql, QueryStream,
+};
+
+/// A query object with bind parameters.
+#[derive(Debug)]
+pub struct Query<'a> {
+    sql: Cow<'a, str>,
+    params: Vec<ColumnData<'a>>,
+}
+
+impl<'a> Query<'a> {
+    /// Construct a new query object with the given SQL. If the SQL is
+    /// parameterized, the given number of parameters must be bound to the
+    /// object before executing.
+    ///
+    /// The `sql` can define the parameter placement by annotating them with
+    /// `@PN`, where N is the index of the parameter, starting from `1`.
+    pub fn new(sql: impl Into<Cow<'a, str>>) -> Self {
+        Self {
+            sql: sql.into(),
+            params: Vec::new(),
+        }
+    }
+
+    /// Bind a new parameter to the query. Must be called exactly as many times
+    /// as there are parameters in the given SQL. Otherwise the query will fail
+    /// on execution.
+    pub fn bind(&mut self, param: impl IntoSql<'a> + 'a) {
+        self.params.push(param.into_sql());
+    }
+
+    /// Executes SQL statements in the SQL Server, returning the number rows
+    /// affected. Useful for `INSERT`, `UPDATE` and `DELETE` statements. See
+    /// [`Client#execute`] for a simpler API if the parameters are statically
+    /// known.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use tiberius::{Config, Query};
+    /// # use tokio_util::compat::TokioAsyncWriteCompatExt;
+    /// # use std::env;
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let c_str = env::var("TIBERIUS_TEST_CONNECTION_STRING").unwrap_or(
+    /// #     "server=tcp:localhost,1433;integratedSecurity=true;TrustServerCertificate=true".to_owned(),
+    /// # );
+    /// # let config = Config::from_ado_string(&c_str)?;
+    /// # let tcp = tokio::net::TcpStream::connect(config.get_addr()).await?;
+    /// # tcp.set_nodelay(true)?;
+    /// # let mut client = tiberius::Client::connect(config, tcp.compat_write()).await?;
+    /// let mut query = Query::new("INSERT INTO ##Test (id) VALUES (@P1), (@P2), (@P3)");
+    ///
+    /// query.bind("foo");
+    /// query.bind(2i32);
+    /// query.bind(String::from("bar"));
+    ///
+    /// let results = query.execute(&mut client).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// [`ToSql`]: trait.ToSql.html
+    /// [`FromSql`]: trait.FromSql.html
+    /// [`Client#execute`]: struct.Client.html#method.execute
+    pub async fn execute<'b, S>(self, client: &'b mut Client<S>) -> crate::Result<ExecuteResult>
+    where
+        S: AsyncRead + AsyncWrite + Unpin + Send,
+    {
+        client.connection.flush_stream().await?;
+
+        let rpc_params = Client::<S>::rpc_params(self.sql);
+
+        client
+            .rpc_perform_query(RpcProcId::ExecuteSQL, rpc_params, self.params.into_iter())
+            .await?;
+
+        ExecuteResult::new(&mut client.connection).await
+    }
+
+    /// Executes SQL statements in the SQL Server, returning resulting rows.
+    /// Useful for `SELECT` statements. See [`Client#query`] for a simpler API
+    /// if the parameters are statically known.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use tiberius::{Config, Query};
+    /// # use tokio_util::compat::TokioAsyncWriteCompatExt;
+    /// # use std::env;
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let c_str = env::var("TIBERIUS_TEST_CONNECTION_STRING").unwrap_or(
+    /// #     "server=tcp:localhost,1433;integratedSecurity=true;TrustServerCertificate=true".to_owned(),
+    /// # );
+    /// # let config = Config::from_ado_string(&c_str)?;
+    /// # let tcp = tokio::net::TcpStream::connect(config.get_addr()).await?;
+    /// # tcp.set_nodelay(true)?;
+    /// # let mut client = tiberius::Client::connect(config, tcp.compat_write()).await?;
+    /// let mut query = Query::new("SELECT @P1, @P2, @P3");
+    ///
+    /// query.bind(1i32);
+    /// query.bind(2i32);
+    /// query.bind(3i32);
+    ///
+    /// let stream = query.query(&mut client).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// [`QueryStream`]: struct.QueryStream.html
+    /// [`ToSql`]: trait.ToSql.html
+    /// [`FromSql`]: trait.FromSql.html
+    /// [`Client#query`]: struct.Client.html#method.query
+    pub async fn query<'b, S>(self, client: &'b mut Client<S>) -> crate::Result<QueryStream<'b>>
+    where
+        S: AsyncRead + AsyncWrite + Unpin + Send,
+    {
+        client.connection.flush_stream().await?;
+        let rpc_params = Client::<S>::rpc_params(self.sql);
+
+        client
+            .rpc_perform_query(RpcProcId::ExecuteSQL, rpc_params, self.params.into_iter())
+            .await?;
+
+        let ts = TokenStream::new(&mut client.connection);
+        let mut result = QueryStream::new(ts.try_unfold());
+        result.forward_to_metadata().await?;
+
+        Ok(result)
+    }
+}

--- a/src/row.rs
+++ b/src/row.rs
@@ -369,6 +369,7 @@ impl Row {
     /// Use [`try_get`] for a non-panicking version of the function.
     ///
     /// [`try_get`]: #method.try_get
+    #[track_caller]
     pub fn get<'a, R, I>(&'a self, idx: I) -> Option<R>
     where
         R: FromSql<'a>,
@@ -378,6 +379,7 @@ impl Row {
     }
 
     /// Retrieve a column's value for a given column index.
+    #[track_caller]
     pub fn try_get<'a, R, I>(&'a self, idx: I) -> crate::Result<Option<R>>
     where
         R: FromSql<'a>,

--- a/src/tds/numeric.rs
+++ b/src/tds/numeric.rs
@@ -289,6 +289,17 @@ mod bigdecimal_ {
                 Numeric::new_with_scale(value, scale)
             });
     );
+
+    #[cfg(feature = "tds73")]
+    into_sql!(self_,
+            BigDecimal: (ColumnData::Numeric, {
+                let (int, exp) = self_.as_bigint_and_exponent();
+                let value = int.to_i128().expect("Given BigDecimal overflowing the maximum accepted value.");
+                let scale = u8::try_from(exp).expect("Given exponent overflowing the maximum accepted scale (255).");
+
+                Numeric::new_with_scale(value, scale)
+            });
+    );
 }
 
 #[cfg(test)]

--- a/src/to_sql.rs
+++ b/src/to_sql.rs
@@ -65,15 +65,120 @@ pub trait ToSql: Send + Sync {
 }
 
 /// A by-value conversion trait to a TDS type.
-pub trait IntoSql: Send + Sync {
+pub trait IntoSql<'a>: Send + Sync {
     /// Convert to a value understood by the SQL Server. Conversion by-value.
-    fn into_sql(self) -> ColumnData<'static>;
+    fn into_sql(self) -> ColumnData<'a>;
+}
+
+impl<'a> IntoSql<'a> for &'a str {
+    fn into_sql(self) -> ColumnData<'a> {
+        ColumnData::String(Some(Cow::Borrowed(self)))
+    }
+}
+
+impl<'a> IntoSql<'a> for Option<&'a str> {
+    fn into_sql(self) -> ColumnData<'a> {
+        ColumnData::String(self.map(Cow::Borrowed))
+    }
+}
+
+impl<'a> IntoSql<'a> for &'a String {
+    fn into_sql(self) -> ColumnData<'a> {
+        ColumnData::String(Some(Cow::Borrowed(self)))
+    }
+}
+
+impl<'a> IntoSql<'a> for Option<&'a String> {
+    fn into_sql(self) -> ColumnData<'a> {
+        ColumnData::String(self.map(Cow::from))
+    }
+}
+
+impl<'a> IntoSql<'a> for &'a [u8] {
+    fn into_sql(self) -> ColumnData<'a> {
+        ColumnData::Binary(Some(Cow::Borrowed(self)))
+    }
+}
+
+impl<'a> IntoSql<'a> for Option<&'a [u8]> {
+    fn into_sql(self) -> ColumnData<'a> {
+        ColumnData::Binary(self.map(Cow::Borrowed))
+    }
+}
+
+impl<'a> IntoSql<'a> for &'a Vec<u8> {
+    fn into_sql(self) -> ColumnData<'a> {
+        ColumnData::Binary(Some(Cow::from(self)))
+    }
+}
+
+impl<'a> IntoSql<'a> for Option<&'a Vec<u8>> {
+    fn into_sql(self) -> ColumnData<'a> {
+        ColumnData::Binary(self.map(Cow::from))
+    }
+}
+
+impl<'a> IntoSql<'a> for Cow<'a, str> {
+    fn into_sql(self) -> ColumnData<'a> {
+        ColumnData::String(Some(self))
+    }
+}
+
+impl<'a> IntoSql<'a> for Option<Cow<'a, str>> {
+    fn into_sql(self) -> ColumnData<'a> {
+        ColumnData::String(self)
+    }
+}
+
+impl<'a> IntoSql<'a> for Cow<'a, [u8]> {
+    fn into_sql(self) -> ColumnData<'a> {
+        ColumnData::Binary(Some(self))
+    }
+}
+
+impl<'a> IntoSql<'a> for Option<Cow<'a, [u8]>> {
+    fn into_sql(self) -> ColumnData<'a> {
+        ColumnData::Binary(self)
+    }
+}
+
+impl<'a> IntoSql<'a> for &'a XmlData {
+    fn into_sql(self) -> ColumnData<'a> {
+        ColumnData::Xml(Some(Cow::Borrowed(self)))
+    }
+}
+
+impl<'a> IntoSql<'a> for Option<&'a XmlData> {
+    fn into_sql(self) -> ColumnData<'a> {
+        ColumnData::Xml(self.map(Cow::Borrowed))
+    }
+}
+
+impl<'a> IntoSql<'a> for &'a Uuid {
+    fn into_sql(self) -> ColumnData<'a> {
+        ColumnData::Guid(Some(*self))
+    }
+}
+
+impl<'a> IntoSql<'a> for Option<&'a Uuid> {
+    fn into_sql(self) -> ColumnData<'a> {
+        ColumnData::Guid(self.copied())
+    }
 }
 
 into_sql!(self_,
           String: (ColumnData::String, Cow::from(self_));
           Vec<u8>: (ColumnData::Binary, Cow::from(self_));
+          Numeric: (ColumnData::Numeric, self_);
           XmlData: (ColumnData::Xml, Cow::Owned(self_));
+          Uuid: (ColumnData::Guid, self_);
+          bool: (ColumnData::Bit, self_);
+          u8: (ColumnData::U8, self_);
+          i16: (ColumnData::I16, self_);
+          i32: (ColumnData::I32, self_);
+          i64: (ColumnData::I64, self_);
+          f32: (ColumnData::F32, self_);
+          f64: (ColumnData::F64, self_);
 );
 
 to_sql!(self_,


### PR DESCRIPTION
Introduces a new API to perform queries that bind dynamic parameters, making
them easier without needing to cast dyn traits out of the data before using.

The public API is the `Query` struct:

- Initialize with the query string
- Bind parameters one by one
- Either query or execute with a connection

Extends the `IntoSql` implementations to all types, making the binding
by-value, but allowing using references if needed.

In the end, might be we want to remove the `ToSql` completely, but not yet.