### PR TITLE
fix: correctly decode null integers & floats

### DIFF
--- a/src/tds/codec/column_data.rs
+++ b/src/tds/codec/column_data.rs
@@ -34,7 +34,7 @@ use uuid::Uuid;
 
 const MAX_NVARCHAR_SIZE: usize = 1 << 30;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 /// A container of a value that can be represented as a TDS value.
 pub enum ColumnData<'a> {
     /// 8-bit integer, unsigned.

--- a/src/tds/codec/column_data/float.rs
+++ b/src/tds/codec/column_data/float.rs
@@ -1,15 +1,16 @@
 use crate::{error::Error, sql_read_bytes::SqlReadBytes, ColumnData};
 
-pub(crate) async fn decode<R>(src: &mut R) -> crate::Result<ColumnData<'static>>
+pub(crate) async fn decode<R>(src: &mut R, type_len: usize) -> crate::Result<ColumnData<'static>>
 where
     R: SqlReadBytes + Unpin,
 {
     let len = src.read_u8().await? as usize;
 
-    let res = match len {
-        0 => ColumnData::F32(None),
-        4 => ColumnData::F32(Some(src.read_f32_le().await?)),
-        8 => ColumnData::F64(Some(src.read_f64_le().await?)),
+    let res = match (len, type_len) {
+        (0, 4) => ColumnData::F32(None),
+        (0, _) => ColumnData::F64(None),
+        (4, _) => ColumnData::F32(Some(src.read_f32_le().await?)),
+        (8, _) => ColumnData::F64(Some(src.read_f64_le().await?)),
         _ => {
             return Err(Error::Protocol(
                 format!("floatn: length of {} is invalid", len).into(),

--- a/src/tds/codec/column_data/int.rs
+++ b/src/tds/codec/column_data/int.rs
@@ -1,17 +1,20 @@
 use crate::{sql_read_bytes::SqlReadBytes, ColumnData};
 
-pub(crate) async fn decode<R>(src: &mut R) -> crate::Result<ColumnData<'static>>
+pub(crate) async fn decode<R>(src: &mut R, type_len: usize) -> crate::Result<ColumnData<'static>>
 where
     R: SqlReadBytes + Unpin,
 {
     let recv_len = src.read_u8().await? as usize;
 
-    let res = match recv_len {
-        0 => ColumnData::U8(None),
-        1 => ColumnData::U8(Some(src.read_u8().await?)),
-        2 => ColumnData::I16(Some(src.read_i16_le().await?)),
-        4 => ColumnData::I32(Some(src.read_i32_le().await?)),
-        8 => ColumnData::I64(Some(src.read_i64_le().await?)),
+    let res = match (recv_len, type_len) {
+        (0, 1) => ColumnData::U8(None),
+        (0, 2) => ColumnData::I16(None),
+        (0, 4) => ColumnData::I32(None),
+        (0, _) => ColumnData::I64(None),
+        (1, _) => ColumnData::U8(Some(src.read_u8().await?)),
+        (2, _) => ColumnData::I16(Some(src.read_i16_le().await?)),
+        (4, _) => ColumnData::I32(Some(src.read_i32_le().await?)),
+        (8, _) => ColumnData::I64(Some(src.read_i64_le().await?)),
         _ => unimplemented!(),
     };
 

--- a/src/tds/codec/column_data/var_len.rs
+++ b/src/tds/codec/column_data/var_len.rs
@@ -15,8 +15,8 @@ where
 
     let res = match ty {
         Bitn => super::bit::decode(src).await?,
-        Intn => super::int::decode(src).await?,
-        Floatn => super::float::decode(src).await?,
+        Intn => super::int::decode(src, len).await?,
+        Floatn => super::float::decode(src, len).await?,
         Guid => super::guid::decode(src).await?,
         BigChar | BigVarChar | NChar | NVarchar => {
             ColumnData::String(super::string::decode(src, ty, len, collation).await?)


### PR DESCRIPTION
## Overview

Related to https://github.com/prisma/prisma/issues/12796 and https://github.com/prisma/prisma/issues/12798

- All null integers, regardless of their type length, were decoded as `u8`. This causes `quaint` to read null `bigint` as `Int32(None)` instead of `Int64(None)`.
- Same goes for floats. Not sure it's causing any issue atm since we're not differentiating `f32` vs `f64` in the rest of the "Prisma stack", but I did it anyway for good measure.

There were existing tests reading nullable integers, but those tests were only trying to convert the `ColumnData` to a rust primitive type and assert that primitive type. However, because of those `FromSql` implementations 👇 which enable converting a `ColumnData::U8` and `ColumnData::I32` to an `Option<i64>`, tests were passing.

I left those `FromSql` implementations since I'm not sure what they're used for atm.

https://github.com/prisma/tiberius/blob/e88859099fc38e61dd01990567a928872efb08ad/src/from_sql.rs#L64

Tests now _also_ ensure that all integers + floats are decoded as the proper `ColumnData` in the case of null values.