### PR TITLE
Cut down deps, make TLS optional

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,8 +45,9 @@ jobs:
           - azure-sql-edge
         features:
           - "--features=all"
-          - "--no-default-features --features=chrono"
-          - "--no-default-features --features=time"
+          - "--no-default-features --features=native-tls,chrono"
+          - "--no-default-features --features=native-tls,time"
+          - "--no-default-features --features=rustls"
 
     env:
       TIBERIUS_TEST_CONNECTION_STRING: "server=tcp:localhost,1433;user=SA;password=<YourStrong@Passw0rd>;TrustServerCertificate=true"
@@ -191,7 +192,7 @@ jobs:
         database:
           - 2019
         features:
-          - "--features=all,vendored-openssl"
+          - "--no-default-features --features=rustls,chrono,time,tds73,sql-browser-async-std,sql-browser-tokio,sql-browser-smol,integrated-auto-gssapi,rust_decimal,bigdecimal"
 
     env:
       TIBERIUS_TEST_CONNECTION_STRING: "server=tcp:localhost,1433;user=SA;password=<YourStrong@Passw0rd>;TrustServerCertificate=true"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,7 @@ jobs:
           - azure-sql-edge
         features:
           - "--features=all"
+          - "--no-default-features"
           - "--no-default-features --features=native-tls,chrono"
           - "--no-default-features --features=native-tls,time"
           - "--no-default-features --features=rustls"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,8 +46,8 @@ jobs:
         features:
           - "--features=all"
           - "--no-default-features"
-          - "--no-default-features --features=native-tls,chrono"
-          - "--no-default-features --features=native-tls,time"
+          - "--no-default-features --features=chrono"
+          - "--no-default-features --features=time"
           - "--no-default-features --features=rustls"
 
     env:
@@ -193,7 +193,7 @@ jobs:
         database:
           - 2019
         features:
-          - "--no-default-features --features=rustls,chrono,time,tds73,sql-browser-async-std,sql-browser-tokio,sql-browser-smol,integrated-auto-gssapi,rust_decimal,bigdecimal"
+          - "--no-default-features --features=rustls,chrono,time,tds73,sql-browser-async-std,sql-browser-tokio,sql-browser-smol,integrated-auth-gssapi,rust_decimal,bigdecimal"
 
     env:
       TIBERIUS_TEST_CONNECTION_STRING: "server=tcp:localhost,1433;user=SA;password=<YourStrong@Passw0rd>;TrustServerCertificate=true"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,11 +59,10 @@ winauth = { version = "0.0.4", optional = true }
 [target.'cfg(unix)'.dependencies]
 libgssapi = { version = "0.4.5", optional = true, default-features = false }
 
-[target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
-opentls = { version = "0.2.1", features = ["io-async-std"]}
-
-[target.'cfg(not(any(target_os = "macos", target_os = "ios")))'.dependencies]
-async-native-tls = { version = "0.4", features = ["runtime-async-std"] }
+[dependencies.async-native-tls]
+version = "0.4"
+features = ["runtime-async-std"]
+optional = true
 
 [dependencies.tokio]
 version = "1.0"
@@ -119,21 +118,17 @@ optional = true
 version = "1.12.0"
 optional = true
 
-[dependencies.rustls]
-version = "0.20.4"
-features = ["dangerous_configuration"]
-optional = true
-
 [dependencies.tokio-rustls]
 version = "0.23.3"
 optional = true
-
-[dependencies.hyper-rustls]
-version = "0.23.0"
-optional = true
+features = ["dangerous_configuration"]
 
 [dependencies.rustls-pemfile]
-version = "0.3.0"
+version = "0.3"
+optional = true
+
+[dependencies.rustls-native-certs]
+version = "0.6"
 optional = true
 
 [dev-dependencies.uuid]
@@ -174,15 +169,15 @@ all = [
     "integrated-auth-gssapi",
     "rust_decimal",
     "bigdecimal",
-    "use_rustls",
+    "native-tls",
 ]
-default = ["tds73", "winauth"]
-vendored-openssl = ["opentls/vendored", "async-native-tls/vendored"]
+default = ["tds73", "winauth", "native-tls"]
 tds73 = []
 docs = []
 sql-browser-async-std = ["async-std"]
 sql-browser-tokio = ["tokio", "tokio-util"]
 sql-browser-smol = ["async-io", "async-net", "futures-lite"]
 integrated-auth-gssapi = ["libgssapi"]
-bigdecimal = [ "bigdecimal_"]
-use_rustls = ["rustls", "tokio-rustls", "tokio-util", "hyper-rustls", "rustls-pemfile"]
+bigdecimal = ["bigdecimal_"]
+rustls = ["tokio-rustls", "tokio-util", "rustls-pemfile", "rustls-native-certs"]
+native-tls = ["async-native-tls"]

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,7 +1,9 @@
 mod auth;
 mod config;
 mod connection;
+
 mod tls;
+#[cfg(any(feature = "rustls", feature = "native-tls"))]
 mod tls_stream;
 
 pub use auth::*;

--- a/src/client/config.rs
+++ b/src/client/config.rs
@@ -48,7 +48,10 @@ impl Default for Config {
             database: None,
             instance_name: None,
             application_name: None,
+            #[cfg(any(feature = "rustls", feature = "native-tls"))]
             encryption: EncryptionLevel::Required,
+            #[cfg(not(any(feature = "rustls", feature = "native-tls")))]
+            encryption: EncryptionLevel::NotSupported,
             trust: TrustConfig::Default,
             auth: AuthMethod::None,
         }
@@ -323,6 +326,7 @@ pub(crate) trait ConfigString {
             .map(|ca| ca.to_string())
     }
 
+    #[cfg(any(feature = "rustls", feature = "native-tls"))]
     fn encrypt(&self) -> crate::Result<EncryptionLevel> {
         self.dict()
             .get("encrypt")
@@ -333,6 +337,11 @@ pub(crate) trait ConfigString {
                 Err(e) => Err(e),
             })
             .unwrap_or(Ok(EncryptionLevel::Off))
+    }
+
+    #[cfg(not(any(feature = "rustls", feature = "native-tls")))]
+    fn encrypt(&self) -> crate::Result<EncryptionLevel> {
+        Ok(EncryptionLevel::NotSupported)
     }
 
     fn parse_bool<T: AsRef<str>>(v: T) -> crate::Result<bool> {

--- a/src/client/config/ado_net.rs
+++ b/src/client/config/ado_net.rs
@@ -75,6 +75,8 @@ impl ConfigString for AdoNetConfig {
 mod tests {
     use super::*;
     use crate::client::AuthMethod;
+
+    #[cfg(any(feature = "rustls", feature = "native-tls"))]
     use crate::EncryptionLevel;
 
     #[test]
@@ -363,6 +365,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(any(feature = "rustls", feature = "native-tls"))]
     fn encryption_parsing_on() -> crate::Result<()> {
         let test_str = "encrypt=true";
         let ado: AdoNetConfig = test_str.parse()?;
@@ -373,6 +376,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(any(feature = "rustls", feature = "native-tls"))]
     fn encryption_parsing_off() -> crate::Result<()> {
         let test_str = "encrypt=false";
         let ado: AdoNetConfig = test_str.parse()?;
@@ -383,6 +387,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(any(feature = "rustls", feature = "native-tls"))]
     fn encryption_parsing_plaintext() -> crate::Result<()> {
         let test_str = "encrypt=DANGER_PLAINTEXT";
         let ado: AdoNetConfig = test_str.parse()?;
@@ -393,6 +398,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(any(feature = "rustls", feature = "native-tls"))]
     fn encryption_parsing_missing() -> crate::Result<()> {
         let test_str = "";
         let ado: AdoNetConfig = test_str.parse()?;

--- a/src/client/config/jdbc.rs
+++ b/src/client/config/jdbc.rs
@@ -36,6 +36,8 @@ impl ConfigString for JdbcConfig {
 mod tests {
     use super::*;
     use crate::client::AuthMethod;
+
+    #[cfg(any(feature = "rustls", feature = "native-tls"))]
     use crate::EncryptionLevel;
 
     #[test]
@@ -254,6 +256,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(any(feature = "rustls", feature = "native-tls"))]
     fn encryption_parsing_on() -> crate::Result<()> {
         let test_str = "jdbc:sqlserver://my-server.com:4200;encrypt=true;";
         let jdbc: JdbcConfig = test_str.parse()?;
@@ -264,6 +267,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(any(feature = "rustls", feature = "native-tls"))]
     fn encryption_parsing_off() -> crate::Result<()> {
         let test_str = "jdbc:sqlserver://my-server.com:4200;encrypt=false;";
         let jdbc: JdbcConfig = test_str.parse()?;
@@ -274,6 +278,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(any(feature = "rustls", feature = "native-tls"))]
     fn encryption_parsing_plaintext() -> crate::Result<()> {
         let test_str = "jdbc:sqlserver://my-server.com:4200;encrypt=DANGER_PLAINTEXT;";
         let jdbc: JdbcConfig = test_str.parse()?;
@@ -284,6 +289,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(any(feature = "rustls", feature = "native-tls"))]
     fn encryption_parsing_missing() -> crate::Result<()> {
         let test_str = "jdbc:sqlserver://my-server.com:4200;";
         let jdbc: JdbcConfig = test_str.parse()?;

--- a/src/client/tls_stream.rs
+++ b/src/client/tls_stream.rs
@@ -1,272 +1,30 @@
 use crate::Config;
 use futures::{AsyncRead, AsyncWrite};
 
-#[cfg(not(feature = "use_rustls"))]
+#[cfg(feature = "native-tls")]
+mod native_tls_stream;
+
+#[cfg(feature = "rustls")]
+mod rustls_tls_stream;
+
+#[cfg(feature = "native-tls")]
 pub(crate) use native_tls_stream::TlsStream;
-#[cfg(feature = "use_rustls")]
+
+#[cfg(feature = "rustls")]
 pub(crate) use rustls_tls_stream::TlsStream;
 
-#[cfg(feature = "use_rustls")]
+#[cfg(feature = "rustls")]
 pub(crate) async fn create_tls_stream<S: AsyncRead + AsyncWrite + Unpin + Send>(
     config: &Config,
     stream: S,
 ) -> crate::Result<TlsStream<S>> {
     TlsStream::new(config, stream).await
 }
-#[cfg(not(feature = "use_rustls"))]
+
+#[cfg(feature = "native-tls")]
 pub(crate) async fn create_tls_stream<S: AsyncRead + AsyncWrite + Unpin + Send>(
     config: &Config,
     stream: S,
 ) -> crate::Result<TlsStream<S>> {
     native_tls_stream::create_tls_stream(config, stream).await
-}
-
-#[cfg(not(feature = "use_rustls"))]
-mod native_tls_stream {
-    use crate::{
-        client::{config::Config, TrustConfig},
-        error::{Error, IoErrorKind},
-    };
-    #[cfg(all(not(target_os = "macos"), not(target_os = "ios")))]
-    pub(crate) use async_native_tls::TlsStream;
-    #[cfg(not(any(target_os = "macos", target_os = "ios")))]
-    use async_native_tls::{Certificate, TlsConnector};
-    use futures::{AsyncRead, AsyncWrite};
-    #[cfg(any(target_os = "macos", target_os = "ios"))]
-    pub(crate) use opentls::async_io::TlsStream;
-    #[cfg(any(target_os = "macos", target_os = "ios"))]
-    use opentls::{async_io::TlsConnector, Certificate};
-    use std::fs;
-    use tracing::{event, Level};
-
-    pub(crate) async fn create_tls_stream<S: AsyncRead + AsyncWrite + Unpin + Send>(
-        config: &Config,
-        stream: S,
-    ) -> crate::Result<TlsStream<S>> {
-        let mut builder = TlsConnector::new();
-
-        match &config.trust {
-            TrustConfig::CaCertificateLocation(path) => {
-                if let Ok(buf) = fs::read(path) {
-                    let cert = match path.extension() {
-                        Some(ext)
-                        if ext.to_ascii_lowercase() == "pem"
-                            || ext.to_ascii_lowercase() == "crt" =>
-                            {
-                                Some(Certificate::from_pem(&buf)?)
-                            }
-                        Some(ext) if ext.to_ascii_lowercase() == "der" => {
-                            Some(Certificate::from_der(&buf)?)
-                        }
-                        Some(_) | None => return Err(Error::Io {
-                            kind: IoErrorKind::InvalidInput,
-                            message: "Provided CA certificate with unsupported file-extension! Supported types are pem, crt and der.".to_string()}),
-                    };
-                    if let Some(c) = cert {
-                        builder = builder.add_root_certificate(c);
-                    }
-                } else {
-                    return Err(Error::Io {
-                        kind: IoErrorKind::InvalidData,
-                        message: "Could not read provided CA certificate!".to_string(),
-                    });
-                }
-            }
-            TrustConfig::TrustAll => {
-                event!(
-                    Level::WARN,
-                    "Trusting the server certificate without validation."
-                );
-
-                builder = builder.danger_accept_invalid_certs(true);
-                builder = builder.danger_accept_invalid_hostnames(true);
-                builder = builder.use_sni(false);
-            }
-            TrustConfig::Default => {
-                event!(Level::INFO, "Using default trust configuration.");
-            }
-        }
-
-        Ok(builder.connect(config.get_host(), stream).await?)
-    }
-}
-
-#[cfg(feature = "use_rustls")]
-mod rustls_tls_stream {
-    use crate::{
-        client::{config::Config, TrustConfig},
-        error::IoErrorKind,
-        Error,
-    };
-    use futures::{AsyncRead, AsyncWrite};
-    use hyper_rustls::ConfigBuilderExt;
-    use rustls::client::HandshakeSignatureValid;
-    use rustls::internal::msgs::handshake::DigitallySignedStruct;
-    use rustls::{
-        client::{ServerCertVerified, ServerCertVerifier},
-        Certificate, Error as RustlsError, RootCertStore, ServerName,
-    };
-    use std::{fs, io};
-    use std::{
-        pin::Pin,
-        sync::Arc,
-        task::{Context, Poll},
-        time::SystemTime,
-    };
-    use tokio_rustls::{rustls::ClientConfig, TlsConnector};
-    use tokio_util::compat::{Compat, FuturesAsyncReadCompatExt, TokioAsyncReadCompatExt};
-    use tracing::{event, Level};
-
-    impl From<tokio_rustls::webpki::Error> for Error {
-        fn from(e: tokio_rustls::webpki::Error) -> Self {
-            crate::Error::Tls(e.to_string())
-        }
-    }
-
-    pub(crate) struct TlsStream<S: AsyncRead + AsyncWrite + Unpin + Send>(
-        Compat<tokio_rustls::client::TlsStream<Compat<S>>>,
-    );
-
-    struct NoCertVerifier;
-
-    impl ServerCertVerifier for NoCertVerifier {
-        fn verify_server_cert(
-            &self,
-            _end_entity: &Certificate,
-            _intermediates: &[Certificate],
-            _server_name: &ServerName,
-            _scts: &mut dyn Iterator<Item = &[u8]>,
-            _ocsp_response: &[u8],
-            _now: SystemTime,
-        ) -> Result<ServerCertVerified, RustlsError> {
-            Ok(ServerCertVerified::assertion())
-        }
-
-        fn verify_tls12_signature(
-            &self,
-            _message: &[u8],
-            _cert: &Certificate,
-            _dss: &DigitallySignedStruct,
-        ) -> Result<HandshakeSignatureValid, RustlsError> {
-            Ok(HandshakeSignatureValid::assertion())
-        }
-    }
-
-    fn get_server_name(config: &Config) -> crate::Result<ServerName> {
-        match (ServerName::try_from(config.get_host()), &config.trust) {
-            (Ok(sn), _) => Ok(sn),
-            (Err(_), TrustConfig::TrustAll) => {
-                Ok(ServerName::try_from("placeholder.domain.com").unwrap())
-            }
-            (Err(e), _) => Err(crate::Error::Tls(e.to_string())),
-        }
-    }
-
-    impl<S: AsyncRead + AsyncWrite + Unpin + Send> TlsStream<S> {
-        pub(super) async fn new(config: &Config, stream: S) -> crate::Result<Self> {
-            event!(Level::INFO, "Performing a TLS handshake");
-
-            let builder = ClientConfig::builder().with_safe_defaults();
-
-            let client_config = match &config.trust {
-                TrustConfig::CaCertificateLocation(path) => {
-                    if let Ok(buf) = fs::read(path) {
-                        let cert = match path.extension() {
-                            Some(ext)
-                            if ext.to_ascii_lowercase() == "pem"
-                                || ext.to_ascii_lowercase() == "crt" =>
-                                {
-                                    let pem_cert = rustls_pemfile::certs(&mut buf.as_slice())?;
-                                    if pem_cert.len() != 1 {
-                                        return Err(crate::Error::Io {
-                                            kind: IoErrorKind::InvalidInput,
-                                            message: format!("Certificate file {} contain 0 or more than 1 certs", path.to_string_lossy()),
-                                        });
-                                    }
-
-                                    Certificate(pem_cert.into_iter().next().unwrap())
-                                }
-                            Some(ext) if ext.to_ascii_lowercase() == "der" => {
-                                Certificate(buf)
-                            }
-                            Some(_) | None => return Err(crate::Error::Io {
-                                kind: IoErrorKind::InvalidInput,
-                                message: "Provided CA certificate with unsupported file-extension! Supported types are pem, crt and der.".to_string(),
-                            }),
-                        };
-                        let mut cert_store = RootCertStore::empty();
-                        cert_store.add(&cert)?;
-                        builder
-                            .with_root_certificates(cert_store)
-                            .with_no_client_auth()
-                    } else {
-                        return Err(Error::Io {
-                            kind: IoErrorKind::InvalidData,
-                            message: "Could not read provided CA certificate!".to_string(),
-                        });
-                    }
-                }
-                TrustConfig::TrustAll => {
-                    event!(
-                        Level::WARN,
-                        "Trusting the server certificate without validation."
-                    );
-                    let mut config = builder.with_native_roots().with_no_client_auth();
-                    config
-                        .dangerous()
-                        .set_certificate_verifier(Arc::new(NoCertVerifier {}));
-                    // config.enable_sni = false;
-                    config
-                }
-                TrustConfig::Default => {
-                    event!(Level::INFO, "Using default trust configuration.");
-                    builder.with_native_roots().with_no_client_auth()
-                }
-            };
-
-            let connector = TlsConnector::from(Arc::new(client_config));
-
-            let tls_stream = connector
-                .connect(get_server_name(config)?, stream.compat())
-                .await?;
-
-            Ok(TlsStream(tls_stream.compat()))
-        }
-
-        pub(crate) fn get_mut(&mut self) -> &mut S {
-            self.0.get_mut().get_mut().0.get_mut()
-        }
-    }
-
-    impl<S: AsyncRead + AsyncWrite + Unpin + Send> AsyncRead for TlsStream<S> {
-        fn poll_read(
-            self: Pin<&mut Self>,
-            cx: &mut Context<'_>,
-            buf: &mut [u8],
-        ) -> Poll<io::Result<usize>> {
-            let inner = Pin::get_mut(self);
-            Pin::new(&mut inner.0).poll_read(cx, buf)
-        }
-    }
-
-    impl<S: AsyncRead + AsyncWrite + Unpin + Send> AsyncWrite for TlsStream<S> {
-        fn poll_write(
-            self: Pin<&mut Self>,
-            cx: &mut Context<'_>,
-            buf: &[u8],
-        ) -> Poll<io::Result<usize>> {
-            let inner = Pin::get_mut(self);
-            Pin::new(&mut inner.0).poll_write(cx, buf)
-        }
-
-        fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-            let inner = Pin::get_mut(self);
-            Pin::new(&mut inner.0).poll_flush(cx)
-        }
-
-        fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-            let inner = Pin::get_mut(self);
-            Pin::new(&mut inner.0).poll_close(cx)
-        }
-    }
 }

--- a/src/client/tls_stream/native_tls_stream.rs
+++ b/src/client/tls_stream/native_tls_stream.rs
@@ -1,0 +1,60 @@
+use crate::{
+    client::{config::Config, TrustConfig},
+    error::{Error, IoErrorKind},
+};
+pub(crate) use async_native_tls::TlsStream;
+use async_native_tls::{Certificate, TlsConnector};
+use futures::{AsyncRead, AsyncWrite};
+use std::fs;
+use tracing::{event, Level};
+
+pub(crate) async fn create_tls_stream<S: AsyncRead + AsyncWrite + Unpin + Send>(
+    config: &Config,
+    stream: S,
+) -> crate::Result<TlsStream<S>> {
+    let mut builder = TlsConnector::new();
+
+    match &config.trust {
+        TrustConfig::CaCertificateLocation(path) => {
+            if let Ok(buf) = fs::read(path) {
+                let cert = match path.extension() {
+                        Some(ext)
+                        if ext.to_ascii_lowercase() == "pem"
+                            || ext.to_ascii_lowercase() == "crt" =>
+                            {
+                                Some(Certificate::from_pem(&buf)?)
+                            }
+                        Some(ext) if ext.to_ascii_lowercase() == "der" => {
+                            Some(Certificate::from_der(&buf)?)
+                        }
+                        Some(_) | None => return Err(Error::Io {
+                            kind: IoErrorKind::InvalidInput,
+                            message: "Provided CA certificate with unsupported file-extension! Supported types are pem, crt and der.".to_string()}),
+                    };
+                if let Some(c) = cert {
+                    builder = builder.add_root_certificate(c);
+                }
+            } else {
+                return Err(Error::Io {
+                    kind: IoErrorKind::InvalidData,
+                    message: "Could not read provided CA certificate!".to_string(),
+                });
+            }
+        }
+        TrustConfig::TrustAll => {
+            event!(
+                Level::WARN,
+                "Trusting the server certificate without validation."
+            );
+
+            builder = builder.danger_accept_invalid_certs(true);
+            builder = builder.danger_accept_invalid_hostnames(true);
+            builder = builder.use_sni(false);
+        }
+        TrustConfig::Default => {
+            event!(Level::INFO, "Using default trust configuration.");
+        }
+    }
+
+    Ok(builder.connect(config.get_host(), stream).await?)
+}

--- a/src/client/tls_stream/rustls_tls_stream.rs
+++ b/src/client/tls_stream/rustls_tls_stream.rs
@@ -1,0 +1,214 @@
+use crate::{
+    client::{config::Config, TrustConfig},
+    error::IoErrorKind,
+    Error,
+};
+use futures::{AsyncRead, AsyncWrite};
+use std::{
+    fs, io,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+    time::SystemTime,
+};
+use tokio_rustls::{
+    rustls::{
+        client::{
+            HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier,
+            WantsTransparencyPolicyOrClientCert,
+        },
+        internal::msgs::handshake::DigitallySignedStruct,
+        Certificate, ClientConfig, ConfigBuilder, Error as RustlsError, RootCertStore, ServerName,
+        WantsVerifier,
+    },
+    TlsConnector,
+};
+use tokio_util::compat::{Compat, FuturesAsyncReadCompatExt, TokioAsyncReadCompatExt};
+use tracing::{event, Level};
+
+impl From<tokio_rustls::webpki::Error> for Error {
+    fn from(e: tokio_rustls::webpki::Error) -> Self {
+        crate::Error::Tls(e.to_string())
+    }
+}
+
+pub(crate) struct TlsStream<S: AsyncRead + AsyncWrite + Unpin + Send>(
+    Compat<tokio_rustls::client::TlsStream<Compat<S>>>,
+);
+
+struct NoCertVerifier;
+
+impl ServerCertVerifier for NoCertVerifier {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &Certificate,
+        _intermediates: &[Certificate],
+        _server_name: &ServerName,
+        _scts: &mut dyn Iterator<Item = &[u8]>,
+        _ocsp_response: &[u8],
+        _now: SystemTime,
+    ) -> Result<ServerCertVerified, RustlsError> {
+        Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &Certificate,
+        _dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, RustlsError> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+}
+
+fn get_server_name(config: &Config) -> crate::Result<ServerName> {
+    match (ServerName::try_from(config.get_host()), &config.trust) {
+        (Ok(sn), _) => Ok(sn),
+        (Err(_), TrustConfig::TrustAll) => {
+            Ok(ServerName::try_from("placeholder.domain.com").unwrap())
+        }
+        (Err(e), _) => Err(crate::Error::Tls(e.to_string())),
+    }
+}
+
+impl<S: AsyncRead + AsyncWrite + Unpin + Send> TlsStream<S> {
+    pub(super) async fn new(config: &Config, stream: S) -> crate::Result<Self> {
+        event!(Level::INFO, "Performing a TLS handshake");
+
+        let builder = ClientConfig::builder().with_safe_defaults();
+
+        let client_config = match &config.trust {
+            TrustConfig::CaCertificateLocation(path) => {
+                if let Ok(buf) = fs::read(path) {
+                    let cert = match path.extension() {
+                            Some(ext)
+                            if ext.to_ascii_lowercase() == "pem"
+                                || ext.to_ascii_lowercase() == "crt" =>
+                                {
+                                    let pem_cert = rustls_pemfile::certs(&mut buf.as_slice())?;
+                                    if pem_cert.len() != 1 {
+                                        return Err(crate::Error::Io {
+                                            kind: IoErrorKind::InvalidInput,
+                                            message: format!("Certificate file {} contain 0 or more than 1 certs", path.to_string_lossy()),
+                                        });
+                                    }
+
+                                    Certificate(pem_cert.into_iter().next().unwrap())
+                                }
+                            Some(ext) if ext.to_ascii_lowercase() == "der" => {
+                                Certificate(buf)
+                            }
+                            Some(_) | None => return Err(crate::Error::Io {
+                                kind: IoErrorKind::InvalidInput,
+                                message: "Provided CA certificate with unsupported file-extension! Supported types are pem, crt and der.".to_string(),
+                            }),
+                        };
+                    let mut cert_store = RootCertStore::empty();
+                    cert_store.add(&cert)?;
+                    builder
+                        .with_root_certificates(cert_store)
+                        .with_no_client_auth()
+                } else {
+                    return Err(Error::Io {
+                        kind: IoErrorKind::InvalidData,
+                        message: "Could not read provided CA certificate!".to_string(),
+                    });
+                }
+            }
+            TrustConfig::TrustAll => {
+                event!(
+                    Level::WARN,
+                    "Trusting the server certificate without validation."
+                );
+                let mut config = builder.with_native_roots().with_no_client_auth();
+                config
+                    .dangerous()
+                    .set_certificate_verifier(Arc::new(NoCertVerifier {}));
+                // config.enable_sni = false;
+                config
+            }
+            TrustConfig::Default => {
+                event!(Level::INFO, "Using default trust configuration.");
+                builder.with_native_roots().with_no_client_auth()
+            }
+        };
+
+        let connector = TlsConnector::from(Arc::new(client_config));
+
+        let tls_stream = connector
+            .connect(get_server_name(config)?, stream.compat())
+            .await?;
+
+        Ok(TlsStream(tls_stream.compat()))
+    }
+
+    pub(crate) fn get_mut(&mut self) -> &mut S {
+        self.0.get_mut().get_mut().0.get_mut()
+    }
+}
+
+impl<S: AsyncRead + AsyncWrite + Unpin + Send> AsyncRead for TlsStream<S> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        let inner = Pin::get_mut(self);
+        Pin::new(&mut inner.0).poll_read(cx, buf)
+    }
+}
+
+impl<S: AsyncRead + AsyncWrite + Unpin + Send> AsyncWrite for TlsStream<S> {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        let inner = Pin::get_mut(self);
+        Pin::new(&mut inner.0).poll_write(cx, buf)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let inner = Pin::get_mut(self);
+        Pin::new(&mut inner.0).poll_flush(cx)
+    }
+
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let inner = Pin::get_mut(self);
+        Pin::new(&mut inner.0).poll_close(cx)
+    }
+}
+
+trait ConfigBuilderExt {
+    fn with_native_roots(self) -> ConfigBuilder<ClientConfig, WantsTransparencyPolicyOrClientCert>;
+}
+
+impl ConfigBuilderExt for ConfigBuilder<ClientConfig, WantsVerifier> {
+    fn with_native_roots(self) -> ConfigBuilder<ClientConfig, WantsTransparencyPolicyOrClientCert> {
+        let mut roots = RootCertStore::empty();
+        let mut valid_count = 0;
+        let mut invalid_count = 0;
+
+        for cert in rustls_native_certs::load_native_certs().expect("could not load platform certs")
+        {
+            let cert = Certificate(cert.0);
+            match roots.add(&cert) {
+                Ok(_) => valid_count += 1,
+                Err(err) => {
+                    tracing::event!(Level::TRACE, "invalid cert der {:?}", cert.0);
+                    tracing::event!(Level::DEBUG, "certificate parsing failed: {:?}", err);
+                    invalid_count += 1
+                }
+            }
+        }
+        tracing::event!(
+            Level::TRACE,
+            "with_native_roots processed {} valid and {} invalid certs",
+            valid_count,
+            invalid_count
+        );
+        assert!(!roots.is_empty(), "no CA certificates found");
+
+        self.with_root_certificates(roots)
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -68,22 +68,7 @@ impl From<uuid::Error> for Error {
     }
 }
 
-#[cfg(any(target_os = "macos", target_os = "ios"))]
-#[cfg_attr(
-    feature = "docs",
-    doc(cfg(any(target_os = "macos", target_os = "ios")))
-)]
-impl From<opentls::Error> for Error {
-    fn from(v: opentls::Error) -> Self {
-        Error::Tls(format!("{}", v))
-    }
-}
-
-#[cfg(not(any(target_os = "macos", target_os = "ios")))]
-#[cfg_attr(
-    feature = "docs",
-    doc(cfg(not(any(target_os = "macos", target_os = "ios"))))
-)]
+#[cfg(feature = "native-tls")]
 impl From<async_native_tls::Error> for Error {
     fn from(v: async_native_tls::Error) -> Self {
         Error::Tls(format!("{}", v))

--- a/src/tds/codec/pre_login.rs
+++ b/src/tds/codec/pre_login.rs
@@ -55,6 +55,7 @@ impl PreloginMessage {
         }
     }
 
+    #[cfg(any(feature = "rustls", feature = "native-tls"))]
     pub fn negotiated_encryption(&self, expected: EncryptionLevel) -> EncryptionLevel {
         match (expected, self.encryption) {
             (EncryptionLevel::NotSupported, EncryptionLevel::NotSupported) => {
@@ -67,6 +68,11 @@ impl PreloginMessage {
             }
             (_, _) => EncryptionLevel::On,
         }
+    }
+
+    #[cfg(not(any(feature = "rustls", feature = "native-tls")))]
+    pub fn negotiated_encryption(&self, _: EncryptionLevel) -> EncryptionLevel {
+        EncryptionLevel::NotSupported
     }
 }
 

--- a/tests/custom-cert.rs
+++ b/tests/custom-cert.rs
@@ -8,7 +8,7 @@ use tokio_util::compat::TokioAsyncWriteCompatExt;
 static LOGGER_SETUP: Once = Once::new();
 
 #[test]
-#[cfg(all(not(target_os = "macos"), not(target_os = "ios")))]
+#[cfg(any(feature = "rustls", feature = "native-tls"))]
 fn connect_to_custom_cert_instance_ado() -> Result<()> {
     LOGGER_SETUP.call_once(|| {
         env_logger::init();
@@ -40,7 +40,7 @@ fn connect_to_custom_cert_instance_ado() -> Result<()> {
 }
 
 #[test]
-#[cfg(all(not(target_os = "macos"), not(target_os = "ios")))]
+#[cfg(any(feature = "rustls", feature = "native-tls"))]
 fn connect_to_custom_cert_instance_jdbc() -> Result<()> {
     LOGGER_SETUP.call_once(|| {
         env_logger::init();


### PR DESCRIPTION
- We do not need hyper for one TLS extension.
- Modules into files.
- Feature flags `native-tls` and `rustls`.
- Docs change
- CI flag changes