### PR TITLE
Handle negative scale from a BigDecimal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ version = "1.6"
 optional = true
 
 [dependencies.bigdecimal_]
-version = "0.2.0"
+version = "0.3"
 optional = true
 package = "bigdecimal"
 

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1638122382,
-        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "flake-utils_2": {
       "locked": {
-        "lastModified": 1637014545,
-        "narHash": "sha256-26IZAc5yzlD9FlDT54io1oqG/bBoyka+FJk5guaX4x4=",
+        "lastModified": 1656928814,
+        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "bba5dcc8e0b20ab664967ad83d24d64cb64ec4f4",
+        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
         "type": "github"
       },
       "original": {
@@ -32,11 +32,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1642104392,
-        "narHash": "sha256-m71b7MgMh9FDv4MnI5sg9MiBVW6DhE1zq+d/KlLWSC8=",
+        "lastModified": 1662019588,
+        "narHash": "sha256-oPEjHKGGVbBXqwwL+UjsveJzghWiWV0n9ogo1X6l4cw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5aaed40d22f0d9376330b6fa413223435ad6fee5",
+        "rev": "2da64a81275b68fdad38af669afeda43d401e94b",
         "type": "github"
       },
       "original": {
@@ -61,11 +61,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1642387353,
-        "narHash": "sha256-CmpIo2whHN1ESXuKl9lL9CRJVK8YuEfV2JURFqmWNmw=",
+        "lastModified": 1662346831,
+        "narHash": "sha256-kV2/98qORIAD1PJG3QMoatDxtj7u1l594YT7QwIuZiA=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "c76db6730b6bc150c49c9dcefc2323785516d1dc",
+        "rev": "10d890fee54e15deec4312fed58d538e3a1a01a6",
         "type": "github"
       },
       "original": {

--- a/src/client/connection.rs
+++ b/src/client/connection.rs
@@ -85,11 +85,7 @@ impl<S: AsyncRead + AsyncWrite + Unpin + Send> Connection<S> {
             buf: BytesMut::new(),
         };
 
-        let fed_auth_required = if let AuthMethod::AADToken(_) = config.auth {
-            true
-        } else {
-            false
-        };
+        let fed_auth_required = matches!(config.auth, AuthMethod::AADToken(_));
 
         let prelogin = connection
             .prelogin(config.encryption, fed_auth_required)

--- a/src/sql_browser.rs
+++ b/src/sql_browser.rs
@@ -37,7 +37,7 @@ fn get_port_from_sql_browser_reply(
     len: usize,
     instance_name: &str,
 ) -> crate::Result<u16> {
-    const DELIMITER: &'static [u8] = b"tcp;";
+    const DELIMITER: &[u8] = b"tcp;";
 
     buf.truncate(len);
 

--- a/src/tds/codec.rs
+++ b/src/tds/codec.rs
@@ -60,5 +60,5 @@ where
         }
     }
 
-    Ok(T::decode(&mut buf)?)
+    T::decode(&mut buf)
 }

--- a/src/tds/codec/token/token_row.rs
+++ b/src/tds/codec/token/token_row.rs
@@ -27,14 +27,14 @@ impl<'a> Encode<BytesMutWithDataColumns<'a>> for TokenRow<'a> {
         dst.put_u8(TokenType::Row as u8);
 
         if self.data.len() != dst.data_columns().len() {
-            Err(crate::Error::BulkInput(
+            return Err(crate::Error::BulkInput(
                 format!(
                     "Expecting {} columns but {} were given",
                     dst.data_columns().len(),
                     self.data.len()
                 )
                 .into(),
-            ))?;
+            ));
         }
 
         for (value, column) in self.data.into_iter().zip(dst.data_columns()) {

--- a/src/tds/numeric.rs
+++ b/src/tds/numeric.rs
@@ -286,7 +286,7 @@ mod bigdecimal_ {
                 let mut value = int.to_i128().expect("Given BigDecimal overflowing the maximum accepted value.");
 
                 if exp < 0 {
-                    value = value * i128::from(10i64.pow(u32::try_from(exp.abs()).expect("BigDecimal exponent overflow")));
+                    value *= i128::from(10i64.pow(u32::try_from(exp.abs()).expect("BigDecimal exponent overflow")));
                 }
 
                 let scale = u8::try_from(std::cmp::max(exp, 0))
@@ -303,7 +303,7 @@ mod bigdecimal_ {
                 let mut value = int.to_i128().expect("Given BigDecimal overflowing the maximum accepted value.");
 
                 if exp < 0 {
-                    value = value * i128::from(10i64.pow(u32::try_from(exp.abs()).expect("BigDecimal exponent overflow")));
+                    value *= i128::from(10i64.pow(u32::try_from(exp.abs()).expect("BigDecimal exponent overflow")));
                 }
 
                 let scale = u8::try_from(std::cmp::max(exp, 0))

--- a/src/tds/numeric.rs
+++ b/src/tds/numeric.rs
@@ -283,8 +283,14 @@ mod bigdecimal_ {
     to_sql!(self_,
             BigDecimal: (ColumnData::Numeric, {
                 let (int, exp) = self_.as_bigint_and_exponent();
-                let value = int.to_i128().expect("Given BigDecimal overflowing the maximum accepted value.");
-                let scale = u8::try_from(exp).expect("Given exponent overflowing the maximum accepted scale (255).");
+                let mut value = int.to_i128().expect("Given BigDecimal overflowing the maximum accepted value.");
+
+                if exp < 0 {
+                    value = value * i128::from(10i64.pow(u32::try_from(exp.abs()).expect("BigDecimal exponent overflow")));
+                }
+
+                let scale = u8::try_from(std::cmp::max(exp, 0))
+                    .expect("Given exponent overflowing the maximum accepted scale (255).");
 
                 Numeric::new_with_scale(value, scale)
             });
@@ -294,8 +300,14 @@ mod bigdecimal_ {
     into_sql!(self_,
             BigDecimal: (ColumnData::Numeric, {
                 let (int, exp) = self_.as_bigint_and_exponent();
-                let value = int.to_i128().expect("Given BigDecimal overflowing the maximum accepted value.");
-                let scale = u8::try_from(exp).expect("Given exponent overflowing the maximum accepted scale (255).");
+                let mut value = int.to_i128().expect("Given BigDecimal overflowing the maximum accepted value.");
+
+                if exp < 0 {
+                    value = value * i128::from(10i64.pow(u32::try_from(exp.abs()).expect("BigDecimal exponent overflow")));
+                }
+
+                let scale = u8::try_from(std::cmp::max(exp, 0))
+                    .expect("Given exponent overflowing the maximum accepted scale (255).");
 
                 Numeric::new_with_scale(value, scale)
             });

--- a/src/tds/numeric.rs
+++ b/src/tds/numeric.rs
@@ -286,11 +286,11 @@ mod bigdecimal_ {
                 let mut value = int.to_i128().expect("Given BigDecimal overflowing the maximum accepted value.");
 
                 if exp < 0 {
-                    value *= i128::from(10i64.pow(u32::try_from(exp.abs()).expect("BigDecimal exponent overflow")));
+                    value *= i128::from(10i64.pow(u32::try_from(exp.abs()).expect("Given BigDecimal exponent underflowing the minimum accepted scale (-9223372036854775808).")));
                 }
 
                 let scale = u8::try_from(std::cmp::max(exp, 0))
-                    .expect("Given exponent overflowing the maximum accepted scale (255).");
+                    .expect("Given BigDecimal exponent overflowing the maximum accepted scale (255).");
 
                 Numeric::new_with_scale(value, scale)
             });
@@ -303,11 +303,11 @@ mod bigdecimal_ {
                 let mut value = int.to_i128().expect("Given BigDecimal overflowing the maximum accepted value.");
 
                 if exp < 0 {
-                    value *= i128::from(10i64.pow(u32::try_from(exp.abs()).expect("BigDecimal exponent overflow")));
+                    value *= i128::from(10i64.pow(u32::try_from(exp.abs()).expect("Given BigDecimal exponent underflowing the minimum accepted scale (-9223372036854775808).")));
                 }
 
                 let scale = u8::try_from(std::cmp::max(exp, 0))
-                    .expect("Given exponent overflowing the maximum accepted scale (255).");
+                    .expect("Given BigDecimal exponent overflowing the maximum accepted scale (255).");
 
                 Numeric::new_with_scale(value, scale)
             });

--- a/src/tds/numeric.rs
+++ b/src/tds/numeric.rs
@@ -285,6 +285,12 @@ mod bigdecimal_ {
                 let (int, exp) = self_.as_bigint_and_exponent();
                 let mut value = int.to_i128().expect("Given BigDecimal overflowing the maximum accepted value.");
 
+                // SQL Server cannot store negative scales, so we have
+                // to convert the number to the correct exponent
+                // before storing.
+                //
+                // E.g. `Decimal(9, -3)` would be stored as
+                // `Decimal(9000, 0)`.
                 if exp < 0 {
                     value *= i128::from(10i64.pow(u32::try_from(exp.abs()).expect("Given BigDecimal exponent underflowing the minimum accepted scale (-9223372036854775808).")));
                 }
@@ -302,6 +308,12 @@ mod bigdecimal_ {
                 let (int, exp) = self_.as_bigint_and_exponent();
                 let mut value = int.to_i128().expect("Given BigDecimal overflowing the maximum accepted value.");
 
+                // SQL Server cannot store negative scales, so we have
+                // to convert the number to the correct exponent
+                // before storing.
+                //
+                // E.g. `Decimal(9, -3)` would be stored as
+                // `Decimal(9000, 0)`.
                 if exp < 0 {
                     value *= i128::from(10i64.pow(u32::try_from(exp.abs()).expect("Given BigDecimal exponent underflowing the minimum accepted scale (-9223372036854775808).")));
                 }

--- a/src/tds/stream/query.rs
+++ b/src/tds/stream/query.rs
@@ -252,7 +252,7 @@ impl<'a> QueryStream<'a> {
     /// results.
     pub async fn into_first_result(self) -> crate::Result<Vec<Row>> {
         let mut results = self.into_results().await?.into_iter();
-        let rows = results.next().unwrap_or_else(Vec::new);
+        let rows = results.next().unwrap_or_default();
 
         Ok(rows)
     }

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -1569,6 +1569,30 @@ mod bigdecimal {
     }
 
     #[test_on_runtimes]
+    async fn handles_scale_underflow_with_bigdecimal<S>(mut conn: tiberius::Client<S>) -> Result<()>
+    where
+        S: AsyncRead + AsyncWrite + Unpin + Send,
+    {
+        use bigdecimal_::num_bigint::BigInt;
+        use num_traits::FromPrimitive;
+        use tiberius::numeric::BigDecimal;
+
+        let int = BigInt::from_i128(90).unwrap();
+        let num = BigDecimal::new(int, -1);
+
+        let row = conn
+            .query("SELECT @P1", &[&num])
+            .await?
+            .into_row()
+            .await?
+            .unwrap();
+
+        assert_eq!(Some(num), row.get(0));
+
+        Ok(())
+    }
+
+    #[test_on_runtimes]
     async fn bigdecimal_type_u64_presentation<S>(mut conn: tiberius::Client<S>) -> Result<()>
     where
         S: AsyncRead + AsyncWrite + Unpin + Send,


### PR DESCRIPTION
This patch fixes an issue with writing `BigDecimal` values to the `decimal`/`numeric` column type in SQL Server. The server numeric is a combination of two numbers: a signed 128-bit integer for the value itself and an unsigned 8-bit integer to define the position of the point in the number.

So a number such as `9.123` is stored as `9123_i128` with `3` as the scale. You count three numbers to the left from the right, and put the point between numbers `9` and `1`.

The `BigDecimal` library handles the scale as a signed integer. In that library, a number `9000` can be written either as `9000` with `0` as the scale, or as `9` with `-3` as the scale which signals us that we have to move the point to the right from the right, adding zeroes to the actual value. So in this case we move the point three steps and end up to the intended value of `9000`. It is a way to optimize the size of the stored value if you have an even number with only zeroes on the right side.

SQL Server cannot do this, they expect the scale to never be a negative value. This means we have to convert a possible negative scale back to zero. It's a quite easy algorithm, so if you get a negative scale from the `BigDecimal`, you store it as zero and multiply the given number as `number^abs(scale)`.

This is fixing at least these issues in Prisma:

https://github.com/prisma/prisma/issues/15079
https://github.com/prisma/prisma/issues/14703