### PR TITLE
Don't load native roots for trust-all config

### DIFF
--- a/src/client/tls_stream/rustls_tls_stream.rs
+++ b/src/client/tls_stream/rustls_tls_stream.rs
@@ -120,7 +120,9 @@ impl<S: AsyncRead + AsyncWrite + Unpin + Send> TlsStream<S> {
                     Level::WARN,
                     "Trusting the server certificate without validation."
                 );
-                let mut config = builder.with_native_roots().with_no_client_auth();
+                let mut config = builder
+                    .with_root_certificates(RootCertStore::empty())
+                    .with_no_client_auth();
                 config
                     .dangerous()
                     .set_certificate_verifier(Arc::new(NoCertVerifier {}));


### PR DESCRIPTION
If we are going to trust any server certificate anyway, there's no point in loading the native trust anchors.