### PR TITLE
Propagate errors correctly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,6 +166,7 @@ reqwest = "0.11.10"
 paste = "1.0"
 indicatif = "0.17"
 chrono = "0.4"
+indoc = "1.0.7"
 
 [package.metadata.docs.rs]
 features = ["all", "docs"]

--- a/flake.lock
+++ b/flake.lock
@@ -32,11 +32,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1662019588,
-        "narHash": "sha256-oPEjHKGGVbBXqwwL+UjsveJzghWiWV0n9ogo1X6l4cw=",
+        "lastModified": 1664195620,
+        "narHash": "sha256-/0V1a1gAR+QbiQe4aCxBoivhkxss0xyt2mBD6yDrgjw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2da64a81275b68fdad38af669afeda43d401e94b",
+        "rev": "62228ccc672ed000f35b1e5c82e4183e46767e52",
         "type": "github"
       },
       "original": {
@@ -61,11 +61,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1662346831,
-        "narHash": "sha256-kV2/98qORIAD1PJG3QMoatDxtj7u1l594YT7QwIuZiA=",
+        "lastModified": 1664247556,
+        "narHash": "sha256-J4vazHU3609ekn7dr+3wfqPo5WGlZVAgV7jfux352L0=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "10d890fee54e15deec4312fed58d538e3a1a01a6",
+        "rev": "524db9c9ea7bc7743bb74cdd45b6d46ea3fcc2ab",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
             pkg-config
             clangStdenv
             llvmPackages.libclang.lib
-            kerberos
+            libkrb5
             rust-bin.stable.latest.default
           ];
           shellHook = with pkgs; ''

--- a/src/client/auth.rs
+++ b/src/client/auth.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct SqlServerAuth {
     user: String,
     password: String,
@@ -25,7 +25,7 @@ impl Debug for SqlServerAuth {
     }
 }
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq)]
 #[cfg(any(all(windows, feature = "winauth"), doc))]
 #[cfg_attr(feature = "docs", doc(all(windows, feature = "winauth")))]
 pub struct WindowsAuth {
@@ -47,7 +47,7 @@ impl Debug for WindowsAuth {
 }
 
 /// Defines the method of authentication to the server.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum AuthMethod {
     /// Authenticate directly with SQL Server.
     SqlServer(SqlServerAuth),

--- a/src/client/config/ado_net.rs
+++ b/src/client/config/ado_net.rs
@@ -21,7 +21,7 @@ impl ConfigString for AdoNetConfig {
 
     fn server(&self) -> crate::Result<ServerDefinition> {
         fn parse_port(parts: &[&str]) -> crate::Result<Option<u16>> {
-            Ok(match parts.get(0) {
+            Ok(match parts.first() {
                 Some(s) => Some(s.parse()?),
                 None => None,
             })

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 
 /// A unified error enum that contains several errors that might occurr during
 /// the lifecycle of this driver
-#[derive(Debug, Clone, Error, PartialEq)]
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
 pub enum Error {
     #[error("An error occured during the attempt of performing I/O: {}", message)]
     /// An error occured when performing I/O to the server.

--- a/src/error.rs
+++ b/src/error.rs
@@ -65,6 +65,16 @@ pub enum Error {
     BulkInput(Cow<'static, str>),
 }
 
+impl Error {
+    /// True, if the error was caused by a deadlock.
+    pub fn is_deadlock(&self) -> bool {
+        match self {
+            Error::Server(e) => e.code() == 1205,
+            _ => false,
+        }
+    }
+}
+
 impl From<uuid::Error> for Error {
     fn from(e: uuid::Error) -> Self {
         Self::Conversion(format!("Error convertiong a Guid value {}", e).into())

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 
 /// A unified error enum that contains several errors that might occurr during
 /// the lifecycle of this driver
-#[derive(Debug, Clone, Error)]
+#[derive(Debug, Clone, Error, PartialEq)]
 pub enum Error {
     #[error("An error occured during the attempt of performing I/O: {}", message)]
     /// An error occured when performing I/O to the server.
@@ -68,9 +68,15 @@ pub enum Error {
 impl Error {
     /// True, if the error was caused by a deadlock.
     pub fn is_deadlock(&self) -> bool {
+        self.code().map(|c| c == 1205).unwrap_or(false)
+    }
+
+    /// Returns the error code, if the error originates from the
+    /// server.
+    pub fn code(&self) -> Option<u32> {
         match self {
-            Error::Server(e) => e.code() == 1205,
-            _ => false,
+            Error::Server(e) => Some(e.code()),
+            _ => None,
         }
     }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -8,7 +8,7 @@ macro_rules! uint_enum {
     };
 
     ($( #[$gattr:meta] )* ( $($vis:tt)* ) enum $ty:ident { $( $( #[$attr:meta] )* $variant:ident = $val:expr,)* }) => {
-        #[derive(Debug, Copy, Clone, PartialEq)]
+        #[derive(Debug, Copy, Clone, PartialEq, Eq)]
         $( #[$gattr] )*
         #[allow(missing_docs)]
         $( $vis )* enum $ty {

--- a/src/row.rs
+++ b/src/row.rs
@@ -24,7 +24,7 @@ impl Column {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 /// The type of the column.
 pub enum ColumnType {
     /// The column doesn't have a specified type.

--- a/src/tds/codec/login.rs
+++ b/src/tds/codec/login.rs
@@ -29,7 +29,7 @@ impl Default for FeatureLevel {
 
 impl FeatureLevel {
     pub fn done_row_count_bytes(self) -> u8 {
-        if self as u8 >= FeatureLevel::SqlServer2005 as u8 {
+        if self as u32 >= FeatureLevel::SqlServer2005 as u32 {
             8
         } else {
             4
@@ -39,7 +39,7 @@ impl FeatureLevel {
 
 #[bitflags]
 #[repr(u8)]
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OptionFlag1 {
     /// The byte order used by client for numeric and datetime data types.
     /// (default: little-endian)
@@ -68,7 +68,7 @@ pub enum OptionFlag1 {
 
 #[bitflags]
 #[repr(u8)]
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OptionFlag2 {
     /// Set if the change to initial language needs to succeed if the connect is
     /// to succeed.
@@ -94,7 +94,7 @@ pub enum OptionFlag2 {
 
 #[bitflags]
 #[repr(u8)]
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OptionFlag3 {
     /// Request to change login's password.
     RequestChangePassword = 1 << 0,
@@ -113,7 +113,7 @@ pub enum OptionFlag3 {
 
 #[bitflags]
 #[repr(u8)]
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LoginTypeFlag {
     /// Use T-SQL syntax.
     UseTSQL = 1 << 0,
@@ -135,7 +135,7 @@ pub(crate) const FED_AUTH_LIBRARYSECURITYTOKEN: u8 = 0x01;
 
 /// https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-tds/773a62b6-ee89-4c02-9e5e-344882630aac
 #[derive(Debug, Clone, Default)]
-#[cfg_attr(test, derive(PartialEq))]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 struct FedAuthExt<'a> {
     fed_auth_echo: bool,
     fed_auth_token: Cow<'a, str>,
@@ -144,7 +144,7 @@ struct FedAuthExt<'a> {
 
 /// the login packet
 #[derive(Debug, Clone, Default)]
-#[cfg_attr(test, derive(PartialEq))]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct LoginMessage<'a> {
     /// the highest TDS version the client supports
     tds_version: FeatureLevel,

--- a/src/tds/codec/rpc_request.rs
+++ b/src/tds/codec/rpc_request.rs
@@ -7,7 +7,7 @@ use std::borrow::Cow;
 
 #[bitflags]
 #[repr(u8)]
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum RpcStatus {
     ByRefValue = 1 << 0,
     DefaultValue = 1 << 1,
@@ -17,7 +17,7 @@ pub enum RpcStatus {
 
 #[bitflags]
 #[repr(u16)]
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum RpcOption {
     WithRecomp = 1 << 0,
     NoMeta = 1 << 1,

--- a/src/tds/codec/token/token_col_metadata.rs
+++ b/src/tds/codec/token/token_col_metadata.rs
@@ -247,7 +247,7 @@ impl Encode<BytesMut> for BaseMetaDataColumn {
 /// A setting a column can hold.
 #[bitflags]
 #[repr(u16)]
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ColumnFlag {
     /// The column can be null.
     Nullable = 1 << 0,

--- a/src/tds/codec/token/token_done.rs
+++ b/src/tds/codec/token/token_done.rs
@@ -13,7 +13,7 @@ pub struct TokenDone {
 
 #[bitflags]
 #[repr(u16)]
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DoneStatus {
     More = 1 << 0,
     Error = 1 << 1,

--- a/src/tds/codec/token/token_error.rs
+++ b/src/tds/codec/token/token_error.rs
@@ -1,7 +1,7 @@
 use crate::{tds::codec::FeatureLevel, SqlReadBytes};
 use std::fmt;
 
-#[derive(Clone, Debug, thiserror::Error)]
+#[derive(Clone, Debug, PartialEq, thiserror::Error)]
 /// An error token returned from the server.
 pub struct TokenError {
     /// ErrorCode

--- a/src/tds/codec/token/token_error.rs
+++ b/src/tds/codec/token/token_error.rs
@@ -1,7 +1,7 @@
 use crate::{tds::codec::FeatureLevel, SqlReadBytes};
 use std::fmt;
 
-#[derive(Clone, Debug, PartialEq, thiserror::Error)]
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
 /// An error token returned from the server.
 pub struct TokenError {
     /// ErrorCode

--- a/src/tds/codec/type_info.rs
+++ b/src/tds/codec/type_info.rs
@@ -16,7 +16,7 @@ pub enum TypeLength {
 }
 
 /// Describes a type of a column.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TypeInfo {
     FixedLen(FixedLenType),
     VarLenSized(VarLenContext),
@@ -32,7 +32,7 @@ pub enum TypeInfo {
     },
 }
 
-#[derive(Clone, Debug, Copy, PartialEq)]
+#[derive(Clone, Debug, Copy, PartialEq, Eq)]
 pub struct VarLenContext {
     r#type: VarLenType,
     len: usize,
@@ -268,11 +268,9 @@ impl TypeInfo {
         }
 
         match VarLenType::try_from(ty) {
-            Err(()) => {
-                return Err(Error::Protocol(
-                    format!("invalid or unsupported column type: {:?}", ty).into(),
-                ))
-            }
+            Err(()) => Err(Error::Protocol(
+                format!("invalid or unsupported column type: {:?}", ty).into(),
+            )),
             Ok(ty) if ty == VarLenType::Xml => {
                 let has_schema = src.read_u8().await?;
 

--- a/src/tds/collation.rs
+++ b/src/tds/collation.rs
@@ -11,7 +11,7 @@ use encoding::{self, Encoding};
 
 use crate::error::Error;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Collation {
     /// LCID ColFlags Version
     info: u32,

--- a/src/tds/stream/token.rs
+++ b/src/tds/stream/token.rs
@@ -83,7 +83,7 @@ where
                 Some(_) => (),
                 None => match last_error {
                     Some(err) => return Err(crate::Error::Server(err)),
-                    None => Err(crate::Error::Protocol("Never got SSPI token.".into())),
+                    None => return Err(crate::Error::Protocol("Never got SSPI token.".into())),
                 },
             }
         }

--- a/src/tds/xml.rs
+++ b/src/tds/xml.rs
@@ -5,7 +5,7 @@ use std::borrow::BorrowMut;
 use std::sync::Arc;
 
 /// Provides information of the location for the schema.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct XmlSchema {
     db_name: String,
     owner: String,
@@ -44,7 +44,7 @@ impl XmlSchema {
 
 /// A representation of XML data in TDS. Holds the data as a UTF-8 string and
 /// and optional information about the schema.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct XmlData {
     data: String,
     schema: Option<Arc<XmlSchema>>,

--- a/tests/deadlocks.rs
+++ b/tests/deadlocks.rs
@@ -1,0 +1,158 @@
+use std::env;
+
+use indoc::indoc;
+use once_cell::sync::Lazy;
+use tiberius::{error::Error, Client, Config};
+use tokio::{net::TcpStream, sync::mpsc};
+use tokio_util::compat::TokioAsyncWriteCompatExt;
+
+static CONN_STR: Lazy<String> = Lazy::new(|| {
+    env::var("TIBERIUS_TEST_CONNECTION_STRING").unwrap_or_else(|_| {
+        "server=tcp:localhost,1433;IntegratedSecurity=true;TrustServerCertificate=true".to_owned()
+    })
+});
+
+/// Two separate actors running queries with their own connections. We
+/// keep them as actors so we can trigger queries that will halt, and
+/// can still continue using our other connection in the main task.
+async fn spawn_actor() -> (
+    mpsc::Sender<&'static str>,
+    mpsc::Receiver<tiberius::Result<()>>,
+) {
+    let (query_sender, mut query_receiver) = mpsc::channel(100);
+    let (response_sender, response_receiver) = mpsc::channel(100);
+
+    tokio::spawn(async move {
+        let config = Config::from_ado_string(&*CONN_STR)?;
+
+        let tcp = TcpStream::connect(config.get_addr()).await?;
+        tcp.set_nodelay(true)?;
+
+        let mut conn = Client::connect(config, tcp.compat_write()).await?;
+
+        while let Some(query) = query_receiver.recv().await {
+            match conn.simple_query(query).await?.into_results().await {
+                Ok(_) => response_sender.send(Ok(())).await.unwrap(),
+                Err(e) => response_sender.send(Err(e)).await.unwrap(),
+            }
+        }
+
+        Result::<(), Error>::Ok(())
+    });
+
+    (query_sender, response_receiver)
+}
+
+#[tokio::test]
+async fn deadlocks_should_not_prevent_further_queries() -> anyhow::Result<()> {
+    let (sender1, mut receiver1) = spawn_actor().await;
+    let (sender2, mut receiver2) = spawn_actor().await;
+
+    let schema = indoc! {r#"
+        DROP TABLE IF EXISTS City;
+        DROP TABLE IF EXISTS Country;
+
+        CREATE TABLE Country
+        (
+            Id         INT PRIMARY KEY,
+            Name       VARCHAR(100) not null,
+            Population INT          not null
+        );
+
+        CREATE TABLE City
+        (
+            Id         INT PRIMARY KEY,
+            CountryId  INT          not null,
+            Name       VARCHAR(100) not null,
+            Population INT          not null,
+            CONSTRAINT fk_country FOREIGN KEY (CountryId) REFERENCES Country (Id)
+        );
+    "#};
+
+    // Create a new schema defined above.
+    sender1.send(schema).await?;
+    receiver1.recv().await;
+
+    // The first connection starts a transaction.
+    sender1.send("BEGIN TRAN").await?;
+    receiver1.recv().await;
+
+    // The second connection starts a transaction.
+    sender2.send("BEGIN TRAN").await?;
+    receiver2.recv().await;
+
+    // The following commands should not still trigger deadlocks.
+    sender1
+        .send("INSERT INTO Country (Id, Name, Population) VALUES (1, 'USA', 12313)")
+        .await?;
+    receiver1.recv().await;
+
+    sender2
+        .send("INSERT INTO Country (Id, Name, Population) VALUES (2, 'Finland', 42069)")
+        .await?;
+    receiver2.recv().await;
+
+    sender1.send("SELECT * FROM Country WHERE id = 1").await?;
+    receiver1.recv().await;
+
+    sender2.send("SELECT * FROM Country WHERE id = 2").await?;
+    receiver2.recv().await;
+
+    sender1
+        .send("INSERT INTO City (Id, CountryId, Name, Population) VALUES (1, 1, 'New York', 12313)")
+        .await?;
+    receiver1.recv().await;
+
+    sender2
+        .send("INSERT INTO City (Id, CountryId, Name, Population) VALUES (2, 2, 'Delhi', 12313)")
+        .await?;
+    receiver2.recv().await;
+
+    // This query will halt forever, therefore we do not yet fetch the
+    // results.
+    sender1
+        .send("SELECT * FROM City WHERE CountryId = 1")
+        .await?;
+
+    // This one causes a deadlock, which can be in either of the connections.
+    sender2
+        .send("SELECT * FROM City WHERE CountryId = 2")
+        .await?;
+
+    // We wait here maximum of five seconds until the deadlock
+    // detector kicks in and one of the results will be an error, the
+    // other transaction can continue.
+    let (res1, res2) = (receiver1.recv().await, receiver2.recv().await);
+
+    match (res1, res2) {
+        (Some(Err(e)), _) if e.is_deadlock() => {
+            // Preventing further locks in the other connection, we
+            // close the transaction in the connection that did not
+            // throw a deadlock error.
+            sender2.send("ROLLBACK").await?;
+            receiver2.recv().await;
+
+            // The deadlocked connection must be able to query again.
+            sender1.send("SELECT * FROM City").await?;
+            let res = receiver1.recv().await.unwrap();
+
+            assert!(res.is_ok());
+        }
+        (_, Some(Err(e))) if e.is_deadlock() => {
+            // Preventing further locks in the other connection, we
+            // close the transaction in the connection that did not
+            // throw a deadlock error.
+            sender1.send("ROLLBACK").await?;
+            receiver1.recv().await;
+
+            // The deadlocked connection must be able to query again.
+            sender2.send("SELECT * FROM City").await?;
+            let res = receiver2.recv().await.unwrap();
+
+            assert!(res.is_ok());
+        }
+        _ => panic!("Excepted one of the connections to be in a deadlock."),
+    }
+
+    Ok(())
+}

--- a/tests/login_errors.rs
+++ b/tests/login_errors.rs
@@ -1,0 +1,22 @@
+use tiberius::{Client, Config};
+use tokio::net::TcpStream;
+use tokio_util::compat::TokioAsyncWriteCompatExt;
+
+#[tokio::test]
+async fn login_errors_are_propagated_on_init() -> anyhow::Result<()> {
+    let conn_str =
+        "server=tcp:localhost,1433;user=SA;password=ObviouslyWrong;TrustServerCertificate=true";
+
+    let config = Config::from_ado_string(conn_str)?;
+    let tcp = TcpStream::connect(config.get_addr()).await?;
+
+    tcp.set_nodelay(true)?;
+
+    let res = Client::connect(config, tcp.compat_write()).await;
+    assert!(res.is_err());
+
+    let err = res.unwrap_err();
+    assert_eq!(Some(18456), err.code());
+
+    Ok(())
+}


### PR DESCRIPTION
We have to consume the whole token stream to the end even if having an error. Error is stored to the stream, and further tokens are all handled before responding to the user.

This way a possible rollback can zero the transaction descriptor, and the connection can be used for further queries without an error.