### PR TITLE
FromSql for f32 and f64 for Rust's Optionals on floats

### DIFF
--- a/src/from_sql.rs
+++ b/src/from_sql.rs
@@ -67,6 +67,28 @@ from_sql!(f64: ColumnData::F64(val) => (*val, val));
 from_sql!(Uuid: ColumnData::Guid(val) => (*val, val));
 from_sql!(Numeric: ColumnData::Numeric(n) => (*n, n));
 
+impl FromSqlOwned for XmlData {
+    fn from_sql_owned(value: ColumnData<'static>) -> crate::Result<Option<Self>> {
+        match value {
+            ColumnData::Xml(data) => Ok(data.map(|data| data.into_owned())),
+            v => Err(crate::Error::Conversion(
+                format!("cannot interpret {:?} as a String value", v).into(),
+            )),
+        }
+    }
+}
+
+impl<'a> FromSql<'a> for &'a XmlData {
+    fn from_sql(value: &'a ColumnData<'static>) -> crate::Result<Option<Self>> {
+        match value {
+            ColumnData::Xml(data) => Ok(data.as_ref().map(|s| s.as_ref())),
+            v => Err(crate::Error::Conversion(
+                format!("cannot interpret {:?} as a String value", v).into(),
+            )),
+        }
+    }
+}
+
 impl FromSqlOwned for String {
     fn from_sql_owned(value: ColumnData<'static>) -> crate::Result<Option<Self>> {
         match value {

--- a/src/from_sql.rs
+++ b/src/from_sql.rs
@@ -72,7 +72,7 @@ impl<'a> FromSql<'a> for f32 {
             ColumnData::F64(data) => {
                 Ok(
                     data.map( |v| v as f32)
-                    // TODO An f64 as f32 could potentially overflow the f32 capacity)
+                    // TODO An f64 as f32 could potentially overflow the f32 capacity) 
                 )
             }
             v => Err(crate::Error::Conversion(

--- a/src/from_sql.rs
+++ b/src/from_sql.rs
@@ -62,10 +62,43 @@ from_sql!(u8: ColumnData::U8(val) => (*val, val), ColumnData::I32(None) => (None
 from_sql!(i16: ColumnData::I16(val) => (*val, val), ColumnData::U8(None) => (None, None), ColumnData::I32(None) => (None, None));
 from_sql!(i32: ColumnData::I32(val) => (*val, val), ColumnData::U8(None) => (None, None));
 from_sql!(i64: ColumnData::I64(val) => (*val, val), ColumnData::U8(None) => (None, None), ColumnData::I32(None) => (None, None));
-from_sql!(f32: ColumnData::F32(val) => (*val, val));
-from_sql!(f64: ColumnData::F64(val) => (*val, val));
 from_sql!(Uuid: ColumnData::Guid(val) => (*val, val));
 from_sql!(Numeric: ColumnData::Numeric(n) => (*n, n));
+
+impl<'a> FromSql<'a> for f32 {
+    fn from_sql(value: &'a ColumnData<'static>) -> crate::Result<Option<Self>> {
+        match value {
+            ColumnData::F32(data) => Ok(*data),
+            ColumnData::F64(data) => {
+                Ok(
+                    data.map( |v| v as f32)
+                    // TODO An f64 as f32 could potentially overflow the f32 capacity)
+                )
+            }
+            v => Err(crate::Error::Conversion(
+                format!("cannot interpret {:?} as an f32 value", v).into(),
+            )),
+        }
+    }
+}
+
+impl<'a> FromSql<'a> for f64 {
+    fn from_sql(value: &'a ColumnData<'static>) -> crate::Result<Option<Self>> {
+        match value {
+            ColumnData::F32(data) => {
+                Ok(data.map( |v| v as f64))
+            },
+            ColumnData::F64(data) => {
+                Ok(*data)
+            },
+            v => {
+                Err(crate::Error::Conversion(
+                    format!("cannot interpret {:?} as an f64 value", v).into(),
+                ))
+            }
+        }
+    }
+}
 
 impl FromSqlOwned for XmlData {
     fn from_sql_owned(value: ColumnData<'static>) -> crate::Result<Option<Self>> {

--- a/src/from_sql.rs
+++ b/src/from_sql.rs
@@ -62,65 +62,10 @@ from_sql!(u8: ColumnData::U8(val) => (*val, val), ColumnData::I32(None) => (None
 from_sql!(i16: ColumnData::I16(val) => (*val, val), ColumnData::U8(None) => (None, None), ColumnData::I32(None) => (None, None));
 from_sql!(i32: ColumnData::I32(val) => (*val, val), ColumnData::U8(None) => (None, None));
 from_sql!(i64: ColumnData::I64(val) => (*val, val), ColumnData::U8(None) => (None, None), ColumnData::I32(None) => (None, None));
+from_sql!(f32: ColumnData::F32(val) => (*val, val));
+from_sql!(f64: ColumnData::F64(val) => (*val, val));
 from_sql!(Uuid: ColumnData::Guid(val) => (*val, val));
 from_sql!(Numeric: ColumnData::Numeric(n) => (*n, n));
-
-impl<'a> FromSql<'a> for f32 {
-    fn from_sql(value: &'a ColumnData<'static>) -> crate::Result<Option<Self>> {
-        match value {
-            ColumnData::F32(data) => Ok(*data),
-            ColumnData::F64(data) => {
-                Ok(
-                    data.map( |v| v as f32)
-                    // TODO An f64 as f32 could potentially overflow the f32 capacity) 
-                )
-            }
-            v => Err(crate::Error::Conversion(
-                format!("cannot interpret {:?} as an f32 value", v).into(),
-            )),
-        }
-    }
-}
-
-impl<'a> FromSql<'a> for f64 {
-    fn from_sql(value: &'a ColumnData<'static>) -> crate::Result<Option<Self>> {
-        match value {
-            ColumnData::F32(data) => {
-                Ok(data.map( |v| v as f64))
-            },
-            ColumnData::F64(data) => {
-                Ok(*data)
-            },
-            v => {
-                Err(crate::Error::Conversion(
-                    format!("cannot interpret {:?} as an f64 value", v).into(),
-                ))
-            }
-        }
-    }
-}
-
-impl FromSqlOwned for XmlData {
-    fn from_sql_owned(value: ColumnData<'static>) -> crate::Result<Option<Self>> {
-        match value {
-            ColumnData::Xml(data) => Ok(data.map(|data| data.into_owned())),
-            v => Err(crate::Error::Conversion(
-                format!("cannot interpret {:?} as a String value", v).into(),
-            )),
-        }
-    }
-}
-
-impl<'a> FromSql<'a> for &'a XmlData {
-    fn from_sql(value: &'a ColumnData<'static>) -> crate::Result<Option<Self>> {
-        match value {
-            ColumnData::Xml(data) => Ok(data.as_ref().map(|s| s.as_ref())),
-            v => Err(crate::Error::Conversion(
-                format!("cannot interpret {:?} as a String value", v).into(),
-            )),
-        }
-    }
-}
 
 impl FromSqlOwned for String {
     fn from_sql_owned(value: ColumnData<'static>) -> crate::Result<Option<Self>> {

--- a/src/tds/codec/token/token_col_metadata.rs
+++ b/src/tds/codec/token/token_col_metadata.rs
@@ -346,6 +346,7 @@ impl BaseMetaDataColumn {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::VarLenContext;
     use crate::sql_read_bytes::test_utils::IntoSqlReadBytes;
 
     #[tokio::test]

--- a/src/tds/codec/token/token_col_metadata.rs
+++ b/src/tds/codec/token/token_col_metadata.rs
@@ -141,7 +141,12 @@ impl BaseMetaDataColumn {
                 VarLenType::Bitn => ColumnData::Bit(None),
                 VarLenType::Decimaln => ColumnData::Numeric(None),
                 VarLenType::Numericn => ColumnData::Numeric(None),
-                VarLenType::Floatn => ColumnData::F32(None),
+                VarLenType::Floatn => {
+                    match cx.len() {
+                        4 => ColumnData::F32(None),
+                        _ => ColumnData::F64(None)
+                    }
+                },
                 VarLenType::Money => ColumnData::F64(None),
                 VarLenType::Datetimen => ColumnData::DateTime(None),
                 #[cfg(feature = "tds73")]

--- a/src/tds/codec/token/token_col_metadata.rs
+++ b/src/tds/codec/token/token_col_metadata.rs
@@ -344,3 +344,39 @@ impl BaseMetaDataColumn {
         Ok(BaseMetaDataColumn { flags, ty })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sql_read_bytes::test_utils::IntoSqlReadBytes;
+
+    #[tokio::test]
+    async fn nullable_floats_decode() {
+        let types = vec![
+            TypeInfo::VarLenSized(VarLenContext::new(
+                VarLenType::Floatn,
+                4,
+                None,
+            )),
+            TypeInfo::VarLenSized(VarLenContext::new(
+                VarLenType::Floatn,
+                8,
+                None,
+            )),
+        ];
+
+        for ti in types {
+            let mut buf = BytesMut::new();
+
+            ti.clone()
+                .encode(&mut buf)
+                .expect("encode should be successful");
+
+            let nti = TypeInfo::decode(&mut buf.into_sql_read_bytes())
+                .await
+                .expect("decode must succeed");
+                
+            assert_eq!(nti, ti);
+        }
+    }
+}

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -2566,7 +2566,7 @@ where
     assert_eq!(Option::<i32>::None, row.get(8));
     assert_eq!(Option::<i64>::None, row.get(9));
     assert_eq!(Option::<f32>::None, row.get(10));
-    assert_eq!(Option::<f32>::None, row.get(11));
+    assert_eq!(Option::<f64>::None, row.get(11));
 
     Ok(())
 }


### PR DESCRIPTION
I am opening this PR because when I work with Rust and tiberius, and I have some `Option<f32>` and `Option<f64>`,
`row.get()`  produces an `Result::unwrap()` on a None value.

I am not proud of the purposed solution, as is just a temporal fix. I would like that the dev team could take it as provisional, review my code and purpose a solution over this initial patch.