### PR TITLE
Close connection explicitly

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -347,6 +347,11 @@ impl<S: AsyncRead + AsyncWrite + Unpin + Send> Client<S> {
         BulkLoadRequest::new(&mut self.connection, columns)
     }
 
+    /// Closes this database connection explicitly.
+    pub async fn close(self) -> crate::Result<()> {
+        self.connection.close().await
+    }
+
     pub(crate) fn rpc_params<'a>(query: impl Into<Cow<'a, str>>) -> Vec<RpcParam<'a>> {
         vec![
             RpcParam {

--- a/src/client/connection.rs
+++ b/src/client/connection.rs
@@ -484,6 +484,10 @@ impl<S: AsyncRead + AsyncWrite + Unpin + Send> Connection<S> {
 
         Ok(self)
     }
+
+    pub(crate) async fn close(mut self) -> crate::Result<()> {
+        self.transport.close().await
+    }
 }
 
 impl<S: AsyncRead + AsyncWrite + Unpin + Send> Stream for Connection<S> {


### PR DESCRIPTION
This PR adds a method allowing users to close the connection explicitly and wait until it is closed.