### PR TITLE
Impl IntoSql for time types and Decimal

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -99,6 +99,16 @@ macro_rules! into_sql {
     }
 }
 
+#[cfg(any(feature = "chrono", feature = "time"))]
+macro_rules! to_sql_and_into_sql {
+    ($target:ident, $( $ty:ty: ($variant:expr, $val:expr) ;)* ) => {
+        $(
+            to_sql!($target, $ty: ($variant, $val););
+            into_sql!($target, $ty: ($variant, $val););
+        )*
+    }
+}
+
 macro_rules! from_sql {
     ($( $ty:ty: $($pat:pat => ($borrowed_val:expr, $owned_val:expr)),* );* ) => {
         $(

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -99,7 +99,12 @@ macro_rules! into_sql {
     }
 }
 
-#[cfg(any(feature = "chrono", feature = "time"))]
+#[cfg(any(
+    feature = "chrono",
+    feature = "time",
+    feature = "rust_decimal",
+    feature = "bigdecimal"
+))]
 macro_rules! to_sql_and_into_sql {
     ($target:ident, $( $ty:ty: ($variant:expr, $val:expr) ;)* ) => {
         $(

--- a/src/tds/numeric.rs
+++ b/src/tds/numeric.rs
@@ -248,7 +248,7 @@ mod decimal {
     );
 
     #[cfg(feature = "tds73")]
-    to_sql!(self_,
+    to_sql_and_into_sql!(self_,
             Decimal: (ColumnData::Numeric, {
                 let unpacked = self_.unpack();
 
@@ -280,32 +280,7 @@ mod bigdecimal_ {
     }));
 
     #[cfg(feature = "tds73")]
-    to_sql!(self_,
-            BigDecimal: (ColumnData::Numeric, {
-                let (int, exp) = self_.as_bigint_and_exponent();
-                // SQL Server cannot store negative scales, so we have
-                // to convert the number to the correct exponent
-                // before storing.
-                //
-                // E.g. `Decimal(9, -3)` would be stored as
-                // `Decimal(9000, 0)`.
-                let (int, exp) = if exp < 0 {
-                    self_.with_scale(0).into_bigint_and_exponent()
-                } else {
-                    (int, exp)
-                };
-
-                let value = int.to_i128().expect("Given BigDecimal overflowing the maximum accepted value.");
-
-                let scale = u8::try_from(std::cmp::max(exp, 0))
-                    .expect("Given BigDecimal exponent overflowing the maximum accepted scale (255).");
-
-                Numeric::new_with_scale(value, scale)
-            });
-    );
-
-    #[cfg(feature = "tds73")]
-    into_sql!(self_,
+    to_sql_and_into_sql!(self_,
             BigDecimal: (ColumnData::Numeric, {
                 let (int, exp) = self_.as_bigint_and_exponent();
                 // SQL Server cannot store negative scales, so we have


### PR DESCRIPTION
This PR adds some `IntoSql` implementations for time types and Decimal, so they can be used in `bind()`.

While doing so, I figured that we can use another macro to remove a bit of code duplication.