### PR TITLE
Disable chrono's oldtime feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ features = ["attributes"]
 [dependencies.chrono]
 version = "0.4"
 optional = true
+default-features = false
 
 [dependencies.time]
 version = "0.3"


### PR DESCRIPTION
To disable the dependency on time 0.1, set chrono `default-features = false`.

- https://github.com/chronotope/chrono/issues/602#issuecomment-1225331424