### PR TITLE
Support configuring a CA certificates bundle

### DIFF
--- a/src/client/config.rs
+++ b/src/client/config.rs
@@ -36,6 +36,7 @@ pub struct Config {
 #[derive(Clone, Debug)]
 pub(crate) enum TrustConfig {
     CaCertificateLocation(PathBuf),
+    CaCertificateBundle(Vec<u8>),
     TrustAll,
     Default,
 }
@@ -127,12 +128,12 @@ impl Config {
     /// storage (or use `trust_cert_ca` instead), using this setting is potentially dangerous.
     ///
     /// # Panics
-    /// Will panic in case `trust_cert_ca` was called before.
+    /// Will panic in case `trust_cert_ca` or `trust_cert_ca_bundle` was called before.
     ///
-    /// - Defaults to `default`, meaning server certificate is validated against system-truststore.
+    /// - Defaults to validating the server certificate is validated against system's certificate storage.
     pub fn trust_cert(&mut self) {
-        if let TrustConfig::CaCertificateLocation(_) = &self.trust {
-            panic!("'trust_cert' and 'trust_cert_ca' are mutual exclusive! Only use one.")
+        if !matches!(&self.trust, TrustConfig::Default) {
+            panic!("'trust_cert'/'trust_cert_ca'/'trust_cert_ca_bundle' are mutual exclusive! Only use one.")
         }
         self.trust = TrustConfig::TrustAll;
     }
@@ -143,14 +144,30 @@ impl Config {
     /// trust-chain.
     ///
     /// # Panics
-    /// Will panic in case `trust_cert` was called before.
+    /// Will panic in case `trust_cert` or `trust_cert_ca_bundle` was called before.
     ///
     /// - Defaults to validating the server certificate is validated against system's certificate storage.
     pub fn trust_cert_ca(&mut self, path: impl ToString) {
-        if let TrustConfig::TrustAll = &self.trust {
-            panic!("'trust_cert' and 'trust_cert_ca' are mutual exclusive! Only use one.")
+        if !matches!(&self.trust, TrustConfig::Default) {
+            panic!("'trust_cert'/'trust_cert_ca'/'trust_cert_ca_bundle' are mutual exclusive! Only use one.")
         } else {
-            self.trust = TrustConfig::CaCertificateLocation(PathBuf::from(path.to_string()))
+            self.trust = TrustConfig::CaCertificateLocation(PathBuf::from(path.to_string()));
+        }
+    }
+
+    /// If set, the server certificate will be validated against the given bundle of PEM-encoded CA certificates.
+    /// Useful when using self-signed certificates on the server without having to disable the
+    /// trust-chain.
+    ///
+    /// # Panics
+    /// Will panic in case `trust_cert` or `trust_cert_ca` was called before.
+    ///
+    /// - Defaults to validating the server certificate is validated against system's certificate storage.
+    pub fn trust_cert_ca_bundle(&mut self, bundle: Vec<u8>) {
+        if !matches!(&self.trust, TrustConfig::Default) {
+            panic!("'trust_cert'/'trust_cert_ca'/'trust_cert_ca_bundle' are mutual exclusive! Only use one.")
+        } else {
+            self.trust = TrustConfig::CaCertificateBundle(bundle);
         }
     }
 

--- a/src/client/tls_stream/opentls_tls_stream.rs
+++ b/src/client/tls_stream/opentls_tls_stream.rs
@@ -8,6 +8,8 @@ use opentls::Certificate;
 use std::fs;
 use tracing::{event, Level};
 
+use super::iter_certs::IterCertBundle;
+
 pub(crate) async fn create_tls_stream<S: AsyncRead + AsyncWrite + Unpin + Send>(
     config: &Config,
     stream: S,
@@ -39,6 +41,11 @@ pub(crate) async fn create_tls_stream<S: AsyncRead + AsyncWrite + Unpin + Send>(
                     kind: IoErrorKind::InvalidData,
                     message: "Could not read provided CA certificate!".to_string(),
                 });
+            }
+        }
+        TrustConfig::CaCertificateBundle(bundle) => {
+            for cert in IterCertBundle::new(bundle) {
+                builder = builder.add_root_certificate(Certificate::from_pem(cert)?);
             }
         }
         TrustConfig::TrustAll => {

--- a/src/client/tls_stream/rustls_tls_stream.rs
+++ b/src/client/tls_stream/rustls_tls_stream.rs
@@ -115,6 +115,16 @@ impl<S: AsyncRead + AsyncWrite + Unpin + Send> TlsStream<S> {
                     });
                 }
             }
+            TrustConfig::CaCertificateBundle(bundle) => {
+                let mut cert_store = RootCertStore::empty();
+                let certs = rustls_pemfile::certs(&mut bundle.as_slice())?;
+                for cert in certs {
+                    cert_store.add(&Certificate(cert))?;
+                }
+                builder
+                    .with_root_certificates(cert_store)
+                    .with_no_client_auth()
+            }
             TrustConfig::TrustAll => {
                 event!(
                     Level::WARN,


### PR DESCRIPTION
The trust_cert_ca() config option configures one specific trusted CA certificate. However, there are two downsides:
- it requires a file path, so an in-memory certificate would have to be written to a temporary file
- it supports loading exactly one certificate, so if you need to load an entire bundle (e.g. the AWS RDS bundle) you're out of luck

The trust_cert_ca_bundle() method implemented here solves both of these issues by taking a bundle of PEM-encoded CA certificates in a Vec<u8> and adding all of them to the TLS context. For cases where a CA bundle needs to be loaded from disk, users can of course simply read the file on their end and pass the contents to trust_cert_ca_bundle.