### PR TITLE
Send ReadOnlyIntent when ApplicationIntent=ReadOnly specified

### DIFF
--- a/src/client/config.rs
+++ b/src/client/config.rs
@@ -31,6 +31,7 @@ pub struct Config {
     pub(crate) encryption: EncryptionLevel,
     pub(crate) trust: TrustConfig,
     pub(crate) auth: AuthMethod,
+    pub(crate) readonly: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -62,6 +63,7 @@ impl Default for Config {
             encryption: EncryptionLevel::NotSupported,
             trust: TrustConfig::Default,
             auth: AuthMethod::None,
+            readonly: false,
         }
     }
 }
@@ -161,6 +163,13 @@ impl Config {
         self.auth = auth;
     }
 
+    /// Sets ApplicationIntent readonly.
+    ///
+    /// - Defaults to `false`.
+    pub fn readonly(&mut self, readnoly: bool) {
+        self.readonly = readnoly;
+    }
+
     pub(crate) fn get_host(&self) -> &str {
         self.host
             .as_deref()
@@ -256,6 +265,8 @@ impl Config {
         }
 
         builder.encryption(s.encrypt()?);
+
+        builder.readonly(s.readonly());
 
         Ok(builder)
     }
@@ -368,5 +379,12 @@ pub(crate) trait ConfigString {
                 "Connection string: Not a valid boolean".into(),
             )),
         }
+    }
+
+    fn readonly(&self) -> bool {
+        self.dict()
+            .get("applicationintent")
+            .filter(|val| *val == "ReadOnly")
+            .is_some()
     }
 }

--- a/src/client/connection.rs
+++ b/src/client/connection.rs
@@ -105,6 +105,7 @@ impl<S: AsyncRead + AsyncWrite + Unpin + Send> Connection<S> {
                 config.database,
                 config.host,
                 config.application_name,
+                config.readonly,
                 prelogin,
             )
             .await?;
@@ -290,6 +291,7 @@ impl<S: AsyncRead + AsyncWrite + Unpin + Send> Connection<S> {
         db: Option<String>,
         server_name: Option<String>,
         application_name: Option<String>,
+        readonly: bool,
         prelogin: PreloginMessage,
     ) -> crate::Result<Self> {
         let mut login_message = LoginMessage::new();
@@ -305,6 +307,8 @@ impl<S: AsyncRead + AsyncWrite + Unpin + Send> Connection<S> {
         if let Some(app_name) = application_name {
             login_message.app_name(app_name);
         }
+
+        login_message.readonly(readonly);
 
         match auth {
             #[cfg(all(windows, feature = "winauth"))]

--- a/src/tds/codec/login.rs
+++ b/src/tds/codec/login.rs
@@ -232,6 +232,14 @@ impl<'a> LoginMessage<'a> {
             nonce,
         })
     }
+
+    pub fn readonly(&mut self, readonly: bool) {
+        if readonly {
+            self.type_flags.insert(LoginTypeFlag::ReadOnlyIntent);
+        } else {
+            self.type_flags.remove(LoginTypeFlag::ReadOnlyIntent);
+        }
+    }
 }
 
 impl<'a> Encode<BytesMut> for LoginMessage<'a> {


### PR DESCRIPTION
In our production environment, we use Always On availability groups and availability group listeners. However, tiberius does not support connecting to readonly replicas, preventing us from utilizing readonly replicas.

To connect to readonly replica via availability group listener, we should specify `ApplicaitonIntent=ReadOnly` in connection string[^1]. It sets `TypeFlags`' `fReadOnlyIntent` bit[^2].

This PR makes tiberius to support `ApplicationIntent=ReadOnly`.

[^1]: https://learn.microsoft.com/en-us/sql/database-engine/availability-groups/windows/configure-read-only-routing-for-an-availability-group-sql-server?view=sql-server-2017
[^2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tds/773a62b6-ee89-4c02-9e5e-344882630aac