### PR TITLE
Allow iterating over the cells in a row

### DIFF
--- a/src/row.rs
+++ b/src/row.rs
@@ -13,6 +13,11 @@ pub struct Column {
 }
 
 impl Column {
+    /// Construct a new Column.
+    pub fn new(name: String, column_type: ColumnType) -> Self {
+        Self { name, column_type }
+    }
+
     /// The name of the column.
     pub fn name(&self) -> &str {
         &self.name
@@ -289,6 +294,11 @@ impl Row {
     /// ```
     pub fn columns(&self) -> &[Column] {
         &self.columns
+    }
+
+    /// Return an iterator over row column-value pairs.
+    pub fn cells(&self) -> impl Iterator<Item = (&Column, &ColumnData<'static>)> {
+        self.columns().iter().zip(self.data.iter())
     }
 
     /// The result set number, starting from zero and increasing if the stream

--- a/src/tds/codec/token/token_row.rs
+++ b/src/tds/codec/token/token_row.rs
@@ -71,6 +71,11 @@ impl<'a> TokenRow<'a> {
         self.data.len()
     }
 
+    /// Returns an iterator over column values.
+    pub fn iter(&self) -> std::slice::Iter<'_, ColumnData<'a>> {
+        self.data.iter()
+    }
+
     /// True if row has no columns.
     pub fn is_empty(&self) -> bool {
         self.data.is_empty()


### PR DESCRIPTION
It is currently possible to iterate over `Row` objects, but only through `.into_iter()` which means the borrow checker will not also let us look at the columns. Thus, it is hard to write generic code that operates on any `Row` object.

This PR exposes a `.cells()` method which allows immutable iteration over the `Row` object. It also exposes a public constructor for `Row` objects so that we can write tests for such generic code.

This addresses the iteration half of prisma/tiberius#278.