### PR TITLE
Allow Row to get ColumnData

### DIFF
--- a/src/row.rs
+++ b/src/row.rs
@@ -385,13 +385,22 @@ impl Row {
         R: FromSql<'a>,
         I: QueryIdx,
     {
+        let data = self.get_column_data(idx)?;
+
+        R::from_sql(data)
+    }
+
+    /// Retrieve a column's data for a given column index.
+    #[track_caller]
+    pub fn get_column_data<'a, I>(&'a self, idx: I) -> crate::Result<ColumnData<'static>>
+    where
+        I: QueryIdx,
+    {
         let idx = idx.idx(self).ok_or_else(|| {
             Error::Conversion(format!("Could not find column with index {}", idx).into())
         })?;
 
-        let data = self.data.get(idx).unwrap();
-
-        R::from_sql(data)
+        self.data.get(idx).unwrap()
     }
 }
 

--- a/src/row.rs
+++ b/src/row.rs
@@ -392,7 +392,7 @@ impl Row {
 
     /// Retrieve a column's data for a given column index.
     #[track_caller]
-    pub fn get_column_data<'a, I>(&'a self, idx: I) -> crate::Result<ColumnData<'static>>
+    pub fn get_column_data<'a, I>(&'a self, idx: I) -> crate::Result<&'a ColumnData<'static>>
     where
         I: QueryIdx,
     {
@@ -400,7 +400,7 @@ impl Row {
             Error::Conversion(format!("Could not find column with index {}", idx).into())
         })?;
 
-        self.data.get(idx).unwrap()
+        Ok(self.data.get(idx).unwrap())
     }
 }
 


### PR DESCRIPTION
When working on data of an unknown type, it's very difficult to get a specific index without explicitly giving the type that we are going to receive. Being able to handle the `ColumnData` instead of needing to provide a concrete type that implements `FromSql` allows this to be handled more conveniently.