### PR TITLE
Fix todo panic

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -63,6 +63,11 @@ pub enum Error {
     #[error("BULK UPLOAD input failure: {0}")]
     /// Invalid input in Bulk Upload
     BulkInput(Cow<'static, str>),
+    #[error("Unimplemented: {0}")]
+    /// Not yet implemented
+    ///
+    /// NOTE: It may be removed in the future.
+    Unimplemented(Cow<'static, str>),
 }
 
 impl Error {

--- a/src/tds/codec/column_data.rs
+++ b/src/tds/codec/column_data.rs
@@ -27,7 +27,7 @@ use super::{Encode, FixedLenType, TypeInfo, VarLenType};
 use crate::tds::time::{Date, DateTime2, DateTimeOffset, Time};
 use crate::{
     tds::{time::DateTime, time::SmallDateTime, xml::XmlData, Numeric},
-    SqlReadBytes,
+    Error, SqlReadBytes,
 };
 use bytes::BufMut;
 pub(crate) use bytes_mut_with_type_info::BytesMutWithTypeInfo;
@@ -133,7 +133,11 @@ impl<'a> ColumnData<'a> {
                 VarLenType::Decimaln | VarLenType::Numericn => {
                     ColumnData::Numeric(Numeric::decode(src, *scale).await?)
                 }
-                _ => todo!(),
+                _ => {
+                    return Err(Error::Unimplemented(
+                        format!("not yet implemented for {:?}", ty).into(),
+                    ))
+                }
             },
             TypeInfo::Xml { schema, size } => xml::decode(src, *size, schema.clone()).await?,
         };
@@ -656,7 +660,7 @@ impl<'a> Encode<BytesMutWithTypeInfo<'a>> for ColumnData<'a> {
             {
                 if let Some(num) = opt {
                     if scale != &num.scale() {
-                        todo!("this still need some work, if client scale not aligned with server, we need to do conversion but will lose precision")
+                        return Err(Error::Unimplemented("this still need some work, if client scale not aligned with server, we need to do conversion but will lose precision".into()));
                     }
                     num.encode(&mut *dst)?;
                 } else {

--- a/src/tds/codec/rpc_request.rs
+++ b/src/tds/codec/rpc_request.rs
@@ -1,5 +1,5 @@
 use super::{AllHeaderTy, Encode, ALL_HEADERS_LEN_TX};
-use crate::{tds::codec::ColumnData, BytesMutWithTypeInfo, Result};
+use crate::{tds::codec::ColumnData, BytesMutWithTypeInfo, Error, Result};
 use bytes::{BufMut, BytesMut};
 use enumflags2::{bitflags, BitFlags};
 use std::borrow::BorrowMut;
@@ -106,7 +106,7 @@ impl<'a> Encode<BytesMut> for TokenRpcRequest<'a> {
             RpcProcIdValue::Name(ref _name) => {
                 //let (left_bytes, _) = try!(write_varchar::<u16>(&mut cursor, name, 0));
                 //assert_eq!(left_bytes, 0);
-                todo!()
+                return Err(Error::Unimplemented("".into()));
             }
         }
 

--- a/src/tds/codec/token/token_col_metadata.rs
+++ b/src/tds/codec/token/token_col_metadata.rs
@@ -6,7 +6,7 @@ use std::{
 use crate::{
     error::Error,
     tds::codec::{Encode, FixedLenType, TokenType, TypeInfo, VarLenType},
-    Column, ColumnData, ColumnType, SqlReadBytes,
+    Column, ColumnData, ColumnType, Result, SqlReadBytes,
 };
 use asynchronous_codec::BytesMut;
 use bytes::BufMut;
@@ -119,8 +119,8 @@ pub struct BaseMetaDataColumn {
 }
 
 impl BaseMetaDataColumn {
-    pub(crate) fn null_value(&self) -> ColumnData<'static> {
-        match &self.ty {
+    pub(crate) fn null_value(&self) -> Result<ColumnData<'static>> {
+        let val = match &self.ty {
             TypeInfo::FixedLen(ty) => match ty {
                 FixedLenType::Null => ColumnData::I32(None),
                 FixedLenType::Int1 => ColumnData::U8(None),
@@ -167,11 +167,17 @@ impl BaseMetaDataColumn {
                 VarLenType::NVarchar => ColumnData::String(None),
                 VarLenType::NChar => ColumnData::String(None),
                 VarLenType::Xml => ColumnData::Xml(None),
-                VarLenType::Udt => todo!("User-defined types not supported"),
+                VarLenType::Udt => {
+                    return Err(Error::Unimplemented(
+                        "User-defined types not supported".into(),
+                    ))
+                }
                 VarLenType::Text => ColumnData::String(None),
                 VarLenType::Image => ColumnData::Binary(None),
                 VarLenType::NText => ColumnData::String(None),
-                VarLenType::SSVariant => todo!(),
+                VarLenType::SSVariant => {
+                    return Err(Error::Unimplemented("SSVariant type not supported".into()))
+                }
             },
             TypeInfo::VarLenSizedPrecision { ty, .. } => match ty {
                 VarLenType::Guid => ColumnData::Guid(None),
@@ -197,14 +203,21 @@ impl BaseMetaDataColumn {
                 VarLenType::NVarchar => ColumnData::String(None),
                 VarLenType::NChar => ColumnData::String(None),
                 VarLenType::Xml => ColumnData::Xml(None),
-                VarLenType::Udt => todo!("User-defined types not supported"),
+                VarLenType::Udt => {
+                    return Err(Error::Unimplemented(
+                        "User-defined types not supported".into(),
+                    ))
+                }
                 VarLenType::Text => ColumnData::String(None),
                 VarLenType::Image => ColumnData::Binary(None),
                 VarLenType::NText => ColumnData::String(None),
-                VarLenType::SSVariant => todo!(),
+                VarLenType::SSVariant => {
+                    return Err(Error::Unimplemented("SSVariant type not supported".into()))
+                }
             },
             TypeInfo::Xml { .. } => ColumnData::Xml(None),
-        }
+        };
+        Ok(val)
     }
 }
 

--- a/src/tds/codec/token/token_row.rs
+++ b/src/tds/codec/token/token_row.rs
@@ -129,7 +129,7 @@ impl TokenRow<'static> {
 
         for (i, column) in col_meta.columns.iter().enumerate() {
             let data = if row_bitmap.is_null(i) {
-                column.base.null_value()
+                column.base.null_value()?
             } else {
                 ColumnData::decode(src, &column.base.ty).await?
             };

--- a/src/tds/codec/type_info.rs
+++ b/src/tds/codec/type_info.rs
@@ -99,7 +99,11 @@ impl Encode<BytesMut> for VarLenContext {
                 dst.put_u32_le(self.len() as u32);
             }
             VarLenType::Xml => (),
-            typ => todo!("encoding {:?} is not supported yet", typ),
+            typ => {
+                return Err(Error::Unimplemented(
+                    format!("encoding {:?} is not supported yet", typ).into(),
+                ))
+            }
         }
 
         if let Some(collation) = self.collation() {
@@ -314,7 +318,11 @@ impl TypeInfo {
                     VarLenType::Image | VarLenType::Text | VarLenType::NText => {
                         src.read_u32_le().await? as usize
                     }
-                    _ => todo!("not yet implemented for {:?}", ty),
+                    _ => {
+                        return Err(Error::Unimplemented(
+                            format!("not yet implemented for {:?}", ty).into(),
+                        ));
+                    }
                 };
 
                 let collation = match ty {


### PR DESCRIPTION
This PR adds an `Unimplemented` to the `Error` enum to indicate something that is not implemented, in place of `todo!` in the code.

`todo!` causes an error in the programme and it is very difficult to catch it, the reason for submitting this PR is that I did encounter it and I couldn't do anything about it, it would just interrupt the execution of the programme. 

```
thread 'tokio-runtime-worker' panicked at 'not yet implemented: not yet implemented for Udt', .../src/tds/codec/type_info.rs:317:26
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

I know this is not good practice, but it can serve as a transition period. Until we fix all the todo, then remove it!

Thanks, tiberius

