### PR TITLE
Implement Sql Traits into ColumnData

### DIFF
--- a/src/tds/codec/column_data.rs
+++ b/src/tds/codec/column_data.rs
@@ -27,7 +27,7 @@ use super::{Encode, FixedLenType, TypeInfo, VarLenType};
 use crate::tds::time::{Date, DateTime2, DateTimeOffset, Time};
 use crate::{
     tds::{time::DateTime, time::SmallDateTime, xml::XmlData, Numeric},
-    SqlReadBytes,
+    FromSql, FromSqlOwned, IntoSql, SqlReadBytes, ToSql,
 };
 use bytes::BufMut;
 pub(crate) use bytes_mut_with_type_info::BytesMutWithTypeInfo;
@@ -686,6 +686,30 @@ impl<'a> Encode<BytesMutWithTypeInfo<'a>> for ColumnData<'a> {
         }
 
         Ok(())
+    }
+}
+
+impl<'a> FromSql<'a> for ColumnData<'a> {
+    fn from_sql(value: &'a ColumnData<'a>) -> crate::Result<Option<Self>> {
+        Ok(Some(value.clone()))
+    }
+}
+
+impl<'a> FromSqlOwned for ColumnData<'a> {
+    fn from_sql_owned(value: ColumnData<'a>) -> crate::Result<Option<Self>> {
+        Ok(Some(value))
+    }
+}
+
+impl<'a> ToSql for ColumnData<'a> {
+    fn to_sql(&self) -> ColumnData<'a> {
+        self.clone()
+    }
+}
+
+impl<'a> IntoSql<'a> for ColumnData<'a> {
+    fn into_sql(self) -> ColumnData<'a> {
+        self
     }
 }
 


### PR DESCRIPTION
Allows using ColumnData as parameters for queries, if you wanted to generically store various types of valid SQL data in one place and bind it directly instead of first converting out of ColumnData, which would of course just convert back to ColumnData as soon as it's put into the query bind. Instead you can just store ColumnData, and provide it to the bind method directly, without any converting back and forth since IntoSql just takes ownership of the ColumnData.

This also resolves my earlier issue of getting generic data from a row by name, however both of these solutions have their own merits by themselves.