### PR TITLE
Named RPC call implementaion with out and table-valued params support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,10 @@ path = "tests/query.rs"
 name = "query"
 
 [[test]]
+path = "tests/command.rs"
+name = "command"
+
+[[test]]
 path = "tests/named-instance-async.rs"
 name = "named-instance-async"
 required-features = ["sql-browser-async-std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ repository = "https://github.com/prisma/tiberius"
 version = "0.12.2"
 
 [workspace]
-members = ["runtimes-macro"]
+members = ["runtimes-macro", "tvp-macro"]
 
 [[test]]
 path = "tests/query.rs"
@@ -161,6 +161,9 @@ version = "1"
 
 [dev-dependencies.runtimes-macro]
 path = "./runtimes-macro"
+
+[dependencies.tvp-macro]
+path = "./tvp-macro"
 
 [dev-dependencies]
 names = "0.14"

--- a/src/command.rs
+++ b/src/command.rs
@@ -177,8 +177,8 @@ impl<'a> Command<'a> {
     /// The same as `bind_table`, but with optional DB type name override
     pub fn bind_table_with_dbtype(
         &mut self,
-        db_type: &'a str,
         name: impl Into<Cow<'a, str>>,
+        db_type: &'a str,
         data: impl TableValue<'a> + 'a,
     ) {
         self.params.push(CommandParam {

--- a/src/command.rs
+++ b/src/command.rs
@@ -126,15 +126,17 @@ impl<'a> Command<'a> {
     /// Example
     ///
     /// ```no_run
-    /// # use tiberius::{numeric::Numeric, Client, Command, TableValueRow};
-    /// # use tokio_util::compat::TokioAsyncWriteCompatExt;
     /// # use std::env;
+    /// # use tiberius::Config;
+    /// # use tiberius::{numeric::Numeric, Command, TableValueRow};
+    /// # use tokio_util::compat::TokioAsyncWriteCompatExt;
     /// #[derive(TableValueRow)]
     /// struct SomeGeoList {
     ///     eid: i32,
     ///     lat: Numeric,
     ///     lon: Numeric,
     /// }
+    /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let c_str = env::var("TIBERIUS_TEST_CONNECTION_STRING").unwrap_or(
     /// #     "server=tcp:localhost,1433;integratedSecurity=true;TrustServerCertificate=true".to_owned(),
@@ -142,7 +144,7 @@ impl<'a> Command<'a> {
     /// # let config = Config::from_ado_string(&c_str)?;
     /// # let tcp = tokio::net::TcpStream::connect(config.get_addr()).await?;
     /// # tcp.set_nodelay(true)?;
-    /// # let mut client = tiberius::Client::connect(config, tcp.compat_write()).await?;
+    /// # let client = tiberius::Client::connect(config, tcp.compat_write()).await?;
     ///
     /// let r1 = SomeGeoList {
     ///     eid: 1,
@@ -178,9 +180,10 @@ impl<'a> Command<'a> {
     /// Example
     ///
     /// ```no_run
-    /// # use tiberius::{numeric::Numeric, Client, Command};
+    /// # use tiberius::{Config, Command};
     /// # use tokio_util::compat::TokioAsyncWriteCompatExt;
     /// # use std::env;
+    /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// # let c_str = env::var("TIBERIUS_TEST_CONNECTION_STRING").unwrap_or(
     /// #     "server=tcp:localhost,1433;integratedSecurity=true;TrustServerCertificate=true".to_owned(),
@@ -195,10 +198,9 @@ impl<'a> Command<'a> {
     /// cmd.bind_out_param("@bar", "bar");
     /// let res = cmd.exec(&mut client).await?.into_command_result().await?;
     ///
-    /// let rv: Option<String> = res.try_return_value("@bar")?;
+    /// let rv: Option<&str> = res.try_return_value("@bar")?;
     /// let rc = res.return_code();
     ///
-    /// println!("And we got bar: {:#?}, return_code: {}", rv, rc);
     /// # Ok(())
     /// # }
     /// ```

--- a/src/command.rs
+++ b/src/command.rs
@@ -174,6 +174,23 @@ impl<'a> Command<'a> {
         });
     }
 
+    /// The same as `bind_table`, but with optional DB type name override
+    pub fn bind_table_with_dbtype(
+        &mut self,
+        db_type: &'a str,
+        name: impl Into<Cow<'a, str>>,
+        data: impl TableValue<'a> + 'a,
+    ) {
+        self.params.push(CommandParam {
+            name: name.into(),
+            out: false,
+            data: CommandParamData::Table(SqlTableData {
+                db_type,
+                ..data.into_sql()
+            }),
+        });
+    }
+
     /// Executes the `Command` in the SQL Server, returning `CommandStream` that
     /// can be collected into `CommandResult` for convinience.
     ///

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,0 +1,265 @@
+use std::borrow::Cow;
+pub use tvp_macro;
+
+use enumflags2::BitFlags;
+use futures_util::io::{AsyncRead, AsyncWrite};
+
+use crate::{
+    tds::{
+        codec::{RpcParam, RpcStatus::ByRefValue, RpcValue, TypeInfoTvp},
+        stream::{CommandStream, TokenStream},
+    },
+    Client, ColumnData, IntoSql,
+};
+
+#[doc(inline)]
+pub use tvp_macro::TableValueRow;
+
+/// Any structure that represents a row in a Table Value parameter must implement this trait
+pub trait TableValueRow<'a> {
+    /// Bind row field values, called by `Command` instance before making the call to the server
+    fn bind_fields(&self, data_row: &mut SqlTableDataRow<'a>); // call data_row.add_field(val) for each field
+    /// Database type name that represents this TVP, like `dbo.MyType`.
+    fn get_db_type() -> &'static str;
+}
+
+/// Implemented as generic for `IntoIterator<Item = TableValueRow>`
+pub trait TableValue<'a> {
+    fn into_sql(self) -> SqlTableData<'a>;
+}
+
+impl<'a, R, C> TableValue<'a> for C
+where
+    R: TableValueRow<'a> + 'a,
+    C: IntoIterator<Item = R>,
+{
+    fn into_sql(self) -> SqlTableData<'a> {
+        let mut data = Vec::new();
+        for row in self.into_iter() {
+            let mut data_row = SqlTableDataRow::new();
+            row.bind_fields(&mut data_row);
+            data.push(data_row);
+        }
+
+        SqlTableData {
+            rows: data,
+            db_type: R::get_db_type(),
+        }
+    }
+}
+
+/// Remote command (Stored Procedure of UDF) with bound parameters
+#[derive(Debug)]
+pub struct Command<'a> {
+    name: Cow<'a, str>,
+    params: Vec<CommandParam<'a>>, // TODO: might make sense to check if param names are unique, but server would recject repeating params anyway
+}
+
+#[derive(Debug)]
+struct CommandParam<'a> {
+    name: Cow<'a, str>,
+    out: bool,
+    data: CommandParamData<'a>,
+}
+
+#[derive(Debug)]
+enum CommandParamData<'a> {
+    Scalar(ColumnData<'a>),
+    Table(SqlTableData<'a>),
+}
+
+#[derive(Debug)]
+pub struct SqlTableData<'a> {
+    rows: Vec<SqlTableDataRow<'a>>,
+    db_type: &'static str,
+}
+
+#[derive(Debug)]
+/// TVP row binding public API
+pub struct SqlTableDataRow<'a> {
+    col_data: Vec<ColumnData<'a>>,
+}
+impl<'a> SqlTableDataRow<'a> {
+    fn new() -> SqlTableDataRow<'a> {
+        SqlTableDataRow {
+            col_data: Vec::new(),
+        }
+    }
+    /// Adds TVP field value to the row. Must be called for each column.
+    /// The values are sent to the server in the same order as these calls.
+    pub fn add_field(&mut self, data: impl IntoSql<'a> + 'a) {
+        self.col_data.push(data.into_sql());
+    }
+}
+
+impl<'a> Command<'a> {
+    /// Constructs a new command object with given name.
+    pub fn new(proc_name: impl Into<Cow<'a, str>>) -> Self {
+        Self {
+            name: proc_name.into(),
+            params: Vec::new(),
+        }
+    }
+
+    /// Binds scalar parameter with the given name to the command.
+    pub fn bind_param(&mut self, name: impl Into<Cow<'a, str>>, data: impl IntoSql<'a> + 'a) {
+        self.params.push(CommandParam {
+            name: name.into(),
+            out: false,
+            data: CommandParamData::Scalar(data.into_sql()),
+        });
+    }
+
+    /// Binds by-ref (OUT) scalar parameter to the command.
+    /// Returned value can be found by the same name in the returned values collection.
+    pub fn bind_out_param(&mut self, name: impl Into<Cow<'a, str>>, data: impl IntoSql<'a> + 'a) {
+        self.params.push(CommandParam {
+            name: name.into(),
+            out: true,
+            data: CommandParamData::Scalar(data.into_sql()),
+        });
+    }
+
+    /// Binds table-valued parameter to the command.
+    /// Provided argument must implement `TableValue` trait.
+    ///
+    /// Example
+    ///
+    /// ```no_run
+    /// # use tiberius::{numeric::Numeric, Client, Command, TableValueRow};
+    /// # use tokio_util::compat::TokioAsyncWriteCompatExt;
+    /// # use std::env;
+    /// #[derive(TableValueRow)]
+    /// struct SomeGeoList {
+    ///     eid: i32,
+    ///     lat: Numeric,
+    ///     lon: Numeric,
+    /// }
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let c_str = env::var("TIBERIUS_TEST_CONNECTION_STRING").unwrap_or(
+    /// #     "server=tcp:localhost,1433;integratedSecurity=true;TrustServerCertificate=true".to_owned(),
+    /// # );
+    /// # let config = Config::from_ado_string(&c_str)?;
+    /// # let tcp = tokio::net::TcpStream::connect(config.get_addr()).await?;
+    /// # tcp.set_nodelay(true)?;
+    /// # let mut client = tiberius::Client::connect(config, tcp.compat_write()).await?;
+    ///
+    /// let r1 = SomeGeoList {
+    ///     eid: 1,
+    ///     lat: Numeric::new_with_scale(10, 6),
+    ///     lon: Numeric::new_with_scale(14, 6),
+    /// };
+    /// let r2 = SomeGeoList {
+    ///     eid: 4,
+    ///     lat: Numeric::new_with_scale(101, 6),
+    ///     lon: Numeric::new_with_scale(142, 6),
+    ///     };
+    ///
+    /// let tbl = vec![r1, r2];
+    ///
+    /// let mut cmd = Command::new("dbo.usp_TheGeoProcedure");
+    ///
+    /// cmd.bind_table("@table", tbl);
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    #[cfg(feature = "tds73")]
+    pub fn bind_table(&mut self, name: impl Into<Cow<'a, str>>, data: impl TableValue<'a> + 'a) {
+        self.params.push(CommandParam {
+            name: name.into(),
+            out: false,
+            data: CommandParamData::Table(data.into_sql()),
+        });
+    }
+
+    /// Executes the `Command` in the SQL Server, returning `CommandStream` that
+    /// can be collected into `CommandResult` for convinience.
+    ///
+    /// Example
+    ///
+    /// ```no_run
+    /// # use tiberius::{numeric::Numeric, Client, Command};
+    /// # use tokio_util::compat::TokioAsyncWriteCompatExt;
+    /// # use std::env;
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let c_str = env::var("TIBERIUS_TEST_CONNECTION_STRING").unwrap_or(
+    /// #     "server=tcp:localhost,1433;integratedSecurity=true;TrustServerCertificate=true".to_owned(),
+    /// # );
+    /// # let config = Config::from_ado_string(&c_str)?;
+    /// # let tcp = tokio::net::TcpStream::connect(config.get_addr()).await?;
+    /// # tcp.set_nodelay(true)?;
+    /// # let mut client = tiberius::Client::connect(config, tcp.compat_write()).await?;
+    /// let mut cmd = Command::new("dbo.usp_SomeStoredProc");
+    ///
+    /// cmd.bind_param("@foo", 34i32);
+    /// cmd.bind_out_param("@bar", "bar");
+    /// let res = cmd.exec(&mut client).await?.into_command_result().await?;
+    ///
+    /// let rv: Option<String> = res.try_return_value("@bar")?;
+    /// let rc = res.return_code();
+    ///
+    /// println!("And we got bar: {:#?}, return_code: {}", rv, rc);
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    pub async fn exec<'b, S>(self, client: &'b mut Client<S>) -> crate::Result<CommandStream<'b>>
+    where
+        S: AsyncRead + AsyncWrite + Unpin + Send,
+    {
+        let rpc_params = Command::build_rpc_params(self.params, client).await?;
+
+        client.connection.flush_stream().await?;
+        client.rpc_run_command(self.name, rpc_params).await?;
+
+        let ts = TokenStream::new(&mut client.connection);
+        let result = CommandStream::new(ts.try_unfold());
+
+        Ok(result)
+    }
+
+    async fn build_rpc_params<'b, S>(
+        cmd_params: Vec<CommandParam<'a>>,
+        client: &'b mut Client<S>,
+    ) -> crate::Result<Vec<RpcParam<'a>>>
+    where
+        S: AsyncRead + AsyncWrite + Unpin + Send,
+    {
+        let mut rpc_params = Vec::new();
+        for p in cmd_params.into_iter() {
+            let rpc_val = match p.data {
+                CommandParamData::Scalar(col) => RpcValue::Scalar(col),
+                CommandParamData::Table(t) => {
+                    let type_info_tvp = TypeInfoTvp::new(
+                        t.db_type,
+                        t.rows.into_iter().map(|r| r.col_data).collect(),
+                    );
+                    // it might make sense to expose some API for the caller so they could cache metadata
+                    let cols_metadata = client
+                        .query_run_for_metadata(format!(
+                            "DECLARE @P AS {};SELECT TOP 0 * FROM @P",
+                            t.db_type
+                        ))
+                        .await?;
+                    RpcValue::Table(if let Some(cm) = cols_metadata {
+                        type_info_tvp.with_metadata(cm)
+                    } else {
+                        type_info_tvp
+                    })
+                }
+            };
+            let rpc_param = RpcParam {
+                name: p.name,
+                flags: if p.out {
+                    BitFlags::from_flag(ByRefValue)
+                } else {
+                    BitFlags::empty()
+                },
+                value: rpc_val,
+            };
+            rpc_params.push(rpc_param);
+        }
+        Ok(rpc_params)
+    }
+}

--- a/src/command.rs
+++ b/src/command.rs
@@ -71,7 +71,7 @@ enum CommandParamData<'a> {
 #[derive(Debug)]
 pub struct SqlTableData<'a> {
     rows: Vec<SqlTableDataRow<'a>>,
-    db_type: &'static str,
+    db_type: &'a str,
 }
 
 #[derive(Debug)]

--- a/src/command.rs
+++ b/src/command.rs
@@ -164,7 +164,6 @@ impl<'a> Command<'a> {
     /// # }
     /// ```
     ///
-    #[cfg(feature = "tds73")]
     pub fn bind_table(&mut self, name: impl Into<Cow<'a, str>>, data: impl TableValue<'a> + 'a) {
         self.params.push(CommandParam {
             name: name.into(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -281,6 +281,7 @@ pub use sql_browser::SqlBrowser;
 pub use tds::{
     codec::{BulkLoadRequest, ColumnData, ColumnFlag, IntoRow, TokenRow, TypeLength},
     numeric,
+    stream::CommandStream,
     stream::QueryStream,
     time, xml, EncryptionLevel,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -257,6 +257,7 @@ pub(crate) extern crate bigdecimal_ as bigdecimal;
 mod macros;
 
 mod client;
+mod command;
 mod from_sql;
 mod query;
 mod sql_read_bytes;
@@ -270,6 +271,7 @@ mod tds;
 mod sql_browser;
 
 pub use client::{AuthMethod, Client, Config};
+pub use command::{Command, SqlTableDataRow, TableValueRow};
 pub(crate) use error::Error;
 pub use from_sql::{FromSql, FromSqlOwned};
 pub use query::Query;

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,7 +1,9 @@
 pub use crate::tds::stream::{QueryItem, ResultMetadata};
 use crate::{
     client::Connection,
-    tds::stream::{ReceivedToken, TokenStream},
+    error::Error,
+    tds::stream::{CommandReturnValue, ReceivedToken, TokenStream},
+    FromSql, Row,
 };
 use futures_util::io::{AsyncRead, AsyncWrite};
 use futures_util::stream::TryStreamExt;
@@ -111,5 +113,102 @@ impl IntoIterator for ExecuteResult {
 
     fn into_iter(self) -> Self::IntoIter {
         self.rows_affected.into_iter()
+    }
+}
+
+/// A result from a command execution, listing the number of affected rows,
+/// return code, values of the OUT params and any possible record sets returned
+/// by the command.
+///
+/// # Example
+///
+/// ```no_run
+/// # use tiberius::{numeric::Numeric, Client, Command};
+/// # use tokio_util::compat::TokioAsyncWriteCompatExt;
+/// # use std::env;
+/// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// # let c_str = env::var("TIBERIUS_TEST_CONNECTION_STRING").unwrap_or(
+/// #     "server=tcp:localhost,1433;integratedSecurity=true;TrustServerCertificate=true".to_owned(),
+/// # );
+/// # let config = Config::from_ado_string(&c_str)?;
+/// # let tcp = tokio::net::TcpStream::connect(config.get_addr()).await?;
+/// # tcp.set_nodelay(true)?;
+/// # let mut client = tiberius::Client::connect(config, tcp.compat_write()).await?;
+/// let mut cmd = Command::new("dbo.usp_SomeStoredProc");
+///
+/// cmd.bind_param("@foo", 34i32);
+/// cmd.bind_out_param("@bar", "bar");
+/// let res = cmd.exec(&mut client).await?.into_command_result().await?;
+///
+/// let rv: Option<String> = res.try_return_value("@bar")?;
+/// let rc = res.return_code();
+/// let ra = res.rows_affected();
+///
+/// println!("And we got bar: {:#?}, return_code: {}", rv, rc);
+///
+/// let rs0 = res.to_query_result(0)
+/// if let Some(rows) = rs0 {
+///     printls!("First record set: {:#?}", rows);
+/// }
+/// # Ok(())
+/// # }
+/// ```
+///
+#[derive(Debug)]
+pub struct CommandResult {
+    pub(crate) rows_affected: Vec<u64>,
+    pub(crate) return_code: u32,
+    pub(crate) return_values: Vec<CommandReturnValue>,
+    pub(crate) query_results: Vec<Vec<Row>>,
+}
+
+impl<'a> CommandResult {
+    /// A slice of numbers of rows affected in the same order as the given
+    /// queries.
+    pub fn rows_affected(&self) -> &[u64] {
+        self.rows_affected.as_slice()
+    }
+
+    /// Return Code for the command. The server must return the code.
+    pub fn return_code(&self) -> u32 {
+        self.return_code
+    }
+
+    /// Number of actually returned values (OUT parameters) available.
+    pub fn return_values_len(&self) -> usize {
+        self.return_values.len()
+    }
+
+    /// Try to get returned value by the OUT parameter name.
+    /// If the value is NUL, `None` returned.
+    pub fn try_return_value<T>(&'a self, name: &str) -> crate::Result<Option<T>>
+    where
+        T: FromSql<'a>,
+    {
+        let idx = self
+            .return_values
+            .iter()
+            .position(|p| p.name.eq(name))
+            .ok_or_else(|| {
+                Error::Conversion(format!("Could not find return value {}", name).into())
+            })?;
+        let col_data = self.return_values.get(idx).unwrap();
+
+        T::from_sql(&col_data.data)
+    }
+
+    /// Get returned record set by its index (zero-based). Ruturns `None` if the index
+    /// is out of range.
+    pub fn to_query_result(&self, idx: usize) -> Option<&Vec<Row>> {
+        self.query_results.get(idx)
+    }
+}
+
+impl IntoIterator for CommandResult {
+    type Item = Vec<Row>;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.query_results.into_iter()
     }
 }

--- a/src/result.rs
+++ b/src/result.rs
@@ -123,9 +123,10 @@ impl IntoIterator for ExecuteResult {
 /// # Example
 ///
 /// ```no_run
-/// # use tiberius::{numeric::Numeric, Client, Command};
+/// # use tiberius::{Config, Command};
 /// # use tokio_util::compat::TokioAsyncWriteCompatExt;
 /// # use std::env;
+/// # #[tokio::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// # let c_str = env::var("TIBERIUS_TEST_CONNECTION_STRING").unwrap_or(
 /// #     "server=tcp:localhost,1433;integratedSecurity=true;TrustServerCertificate=true".to_owned(),
@@ -140,16 +141,11 @@ impl IntoIterator for ExecuteResult {
 /// cmd.bind_out_param("@bar", "bar");
 /// let res = cmd.exec(&mut client).await?.into_command_result().await?;
 ///
-/// let rv: Option<String> = res.try_return_value("@bar")?;
+/// let rv: Option<&str> = res.try_return_value("@bar")?;
 /// let rc = res.return_code();
 /// let ra = res.rows_affected();
 ///
-/// println!("And we got bar: {:#?}, return_code: {}", rv, rc);
-///
-/// let rs0 = res.to_query_result(0)
-/// if let Some(rows) = rs0 {
-///     printls!("First record set: {:#?}", rows);
-/// }
+/// let rs0 = res.to_query_result(0);
 /// # Ok(())
 /// # }
 /// ```

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,4 +1,4 @@
-pub use crate::tds::stream::{QueryItem, ResultMetadata};
+pub use crate::tds::stream::{CommandItem, QueryItem, ResultMetadata};
 use crate::{
     client::Connection,
     error::Error,

--- a/src/tds/codec.rs
+++ b/src/tds/codec.rs
@@ -12,6 +12,7 @@ mod pre_login;
 mod rpc_request;
 mod token;
 mod type_info;
+mod type_info_tvp;
 
 pub use batch_request::*;
 pub use bulk_load::*;
@@ -28,6 +29,7 @@ pub use pre_login::*;
 pub use rpc_request::*;
 pub use token::*;
 pub use type_info::*;
+pub use type_info_tvp::*;
 
 const HEADER_BYTES: usize = 8;
 const ALL_HEADERS_LEN_TX: usize = 22;

--- a/src/tds/codec/type_info_tvp.rs
+++ b/src/tds/codec/type_info_tvp.rs
@@ -1,0 +1,228 @@
+use std::borrow::BorrowMut;
+
+use asynchronous_codec::BytesMut;
+use bytes::BufMut;
+
+use crate::ColumnData;
+
+use super::{BytesMutWithTypeInfo, Encode, FixedLenType, MetaDataColumn, TypeInfo, VarLenContext};
+
+const TVPTYPE: u8 = 0xF3;
+
+#[derive(Debug)]
+pub struct TypeInfoTvp<'a> {
+    scheema_name: &'a str,
+    db_type_name: &'a str,
+    columns: Option<Vec<MetaDataColumn<'a>>>,
+    data: Vec<Vec<ColumnData<'a>>>,
+}
+
+impl<'a> Encode<BytesMut> for TypeInfoTvp<'a> {
+    fn encode(self, dst: &mut BytesMut) -> crate::Result<()> {
+        // TVPTYPE        =   %xF3
+        // TVP_TYPE_INFO  =   TVPTYPE
+        //                    TVP_TYPENAME
+        //                    TVP_COLMETADATA
+        //                    [TVP_ORDER_UNIQUE]
+        //                    [TVP_COLUMN_ORDERING]
+        //                    TVP_END_TOKEN
+
+        dst.put_u8(TVPTYPE);
+        put_b_varchar("", dst); // DB name
+        put_b_varchar(self.scheema_name, dst);
+        put_b_varchar(self.db_type_name, dst);
+
+        if let Some(ref columns_metadata) = self.columns {
+            dst.put_u16_le(columns_metadata.len() as u16);
+            for col in columns_metadata {
+                // TvpColumnMetaData = UserType
+                //                     Flags
+                //                     TYPE_INFO
+                //                     ColName ; Column metadata instance
+                dst.put_u32_le(0_u32);
+                col.base.clone().encode(dst)?; // Arc would look better than this clone, but might be actually slower
+                put_b_varchar("", dst); // 2.2.5.5.5.1: ColName MUST be a zero-length string in the TVP.
+                                        // put_b_varchar(col.col_name, dst);
+            }
+        } else {
+            dst.put_u16_le(0xFFFF_u16); // TVP_NULL_TOKEN, server knows the type (never worked in practice)
+        }
+
+        dst.put_u8(0_u8); // TVP_END_TOKEN
+
+        for row in self.data.into_iter() {
+            dst.put_u8(0x01u8); // TVP_ROW_TOKEN = %x01
+            for (i, col) in row.into_iter().enumerate() {
+                let mut dst_ti = BytesMutWithTypeInfo::new(dst);
+                if let Some(ref metadata) = self.columns {
+                    dst_ti = dst_ti.with_type_info(&metadata[i].base.ty);
+                }
+                col.encode(&mut dst_ti)?;
+            }
+        }
+        // TVP_ROW_TOKEN = %x01 ; A row as defined by TVP_COLMETADATA follows
+        // TvpColumnData = TYPE_VARBYTE ; Actual value must match metadata for the column
+        // AllColumnData = *TvpColumnData ; Chunks of data, one per non-default column defined
+        //                                ; in TVP_COLMETADATA
+        // TVP_ROW       = TVP_ROW_TOKEN
+        //                 AllColumnData
+
+        dst.put_u8(0_u8); // TVP_END_TOKEN
+
+        Ok(())
+    }
+}
+
+fn put_b_varchar<T: AsRef<str>>(s: T, dst: &mut BytesMut) {
+    let len_pos = dst.len();
+    dst.put_u8(0u8);
+    let mut length = 0_u8;
+
+    for chr in s.as_ref().encode_utf16() {
+        dst.put_u16_le(chr);
+        length += 1;
+    }
+    let dst: &mut [u8] = dst.borrow_mut();
+    dst[len_pos] = length;
+}
+
+impl<'a> TypeInfoTvp<'a> {
+    pub fn new(type_name: &'a str, rows: Vec<Vec<ColumnData<'a>>>) -> TypeInfoTvp<'a> {
+        let (scheema_name, db_type_name) = if let Some((s, t)) = type_name.split_once(".") {
+            (s, t)
+        } else {
+            ("", type_name.as_ref())
+        };
+        TypeInfoTvp {
+            scheema_name,
+            db_type_name,
+            columns: None,
+            data: rows,
+        }
+    }
+
+    pub fn with_metadata(self, metadata: Vec<MetaDataColumn<'a>>) -> TypeInfoTvp<'_> {
+        let mut metadata = metadata;
+        // 2.2.5.5.5.3
+        for mdc in metadata.iter_mut() {
+            let ty_replace =
+                match mdc.base.ty {
+                    TypeInfo::FixedLen(ref ty) => {
+                        match ty {
+                            FixedLenType::Int1 => Some(TypeInfo::VarLenSized(VarLenContext::new(
+                                super::VarLenType::Intn,
+                                1,
+                                None,
+                            ))),
+                            FixedLenType::Bit => Some(TypeInfo::VarLenSized(VarLenContext::new(
+                                super::VarLenType::Bitn,
+                                1,
+                                None,
+                            ))),
+                            FixedLenType::Int2 => Some(TypeInfo::VarLenSized(VarLenContext::new(
+                                super::VarLenType::Intn,
+                                2,
+                                None,
+                            ))),
+                            FixedLenType::Int4 => Some(TypeInfo::VarLenSized(VarLenContext::new(
+                                super::VarLenType::Intn,
+                                4,
+                                None,
+                            ))),
+                            FixedLenType::Datetime4 => Some(TypeInfo::VarLenSized(
+                                VarLenContext::new(super::VarLenType::Datetimen, 4, None),
+                            )),
+                            FixedLenType::Float4 => Some(TypeInfo::VarLenSized(
+                                VarLenContext::new(super::VarLenType::Floatn, 4, None),
+                            )),
+                            FixedLenType::Money => Some(TypeInfo::VarLenSized(VarLenContext::new(
+                                super::VarLenType::Money,
+                                8,
+                                None,
+                            ))),
+                            FixedLenType::Datetime => Some(TypeInfo::VarLenSized(
+                                VarLenContext::new(super::VarLenType::Datetimen, 8, None),
+                            )),
+                            FixedLenType::Float8 => Some(TypeInfo::VarLenSized(
+                                VarLenContext::new(super::VarLenType::Floatn, 8, None),
+                            )),
+                            FixedLenType::Money4 => Some(TypeInfo::VarLenSized(
+                                VarLenContext::new(super::VarLenType::Money, 4, None),
+                            )),
+                            FixedLenType::Int8 => Some(TypeInfo::VarLenSized(VarLenContext::new(
+                                super::VarLenType::Intn,
+                                8,
+                                None,
+                            ))),
+                            _ => None,
+                        }
+                    }
+                    // TypeInfo::VarLenSized(ref ctx) => match ctx.r#type() {
+                    //     super::VarLenType::Guid => todo!(),
+                    //     super::VarLenType::Intn => todo!(),
+                    //     super::VarLenType::Bitn => todo!(),
+                    //     super::VarLenType::Decimaln => todo!(),
+                    //     super::VarLenType::Numericn => todo!(),
+                    //     super::VarLenType::Floatn => todo!(),
+                    //     super::VarLenType::Money => todo!(),
+                    //     super::VarLenType::Datetimen => todo!(),
+                    //     super::VarLenType::Daten => todo!(),
+                    //     super::VarLenType::Timen => todo!(),
+                    //     super::VarLenType::Datetime2 => todo!(),
+                    //     super::VarLenType::DatetimeOffsetn => todo!(),
+                    //     super::VarLenType::BigVarBin => todo!(),
+                    //     super::VarLenType::BigVarChar => todo!(),
+                    //     super::VarLenType::BigBinary => todo!(),
+                    //     super::VarLenType::BigChar => todo!(),
+                    //     super::VarLenType::NVarchar => todo!(),
+                    //     super::VarLenType::NChar => todo!(),
+                    //     super::VarLenType::Xml => todo!(),
+                    //     super::VarLenType::Udt => todo!(),
+                    //     super::VarLenType::Text => todo!(),
+                    //     super::VarLenType::Image => todo!(),
+                    //     super::VarLenType::NText => todo!(),
+                    //     super::VarLenType::SSVariant => todo!(),
+                    // },
+                    // TypeInfo::VarLenSizedPrecision {
+                    //     ty,
+                    //     size,
+                    //     precision,
+                    //     scale,
+                    // } => match ty {
+                    //     super::VarLenType::Guid => todo!(),
+                    //     super::VarLenType::Intn => todo!(),
+                    //     super::VarLenType::Bitn => todo!(),
+                    //     super::VarLenType::Decimaln => todo!(),
+                    //     super::VarLenType::Numericn => todo!(),
+                    //     super::VarLenType::Floatn => todo!(),
+                    //     super::VarLenType::Money => todo!(),
+                    //     super::VarLenType::Datetimen => todo!(),
+                    //     super::VarLenType::Daten => todo!(),
+                    //     super::VarLenType::Timen => todo!(),
+                    //     super::VarLenType::Datetime2 => todo!(),
+                    //     super::VarLenType::DatetimeOffsetn => todo!(),
+                    //     super::VarLenType::BigVarBin => todo!(),
+                    //     super::VarLenType::BigVarChar => todo!(),
+                    //     super::VarLenType::BigBinary => todo!(),
+                    //     super::VarLenType::BigChar => todo!(),
+                    //     super::VarLenType::NVarchar => todo!(),
+                    //     super::VarLenType::NChar => todo!(),
+                    //     super::VarLenType::Xml => todo!(),
+                    //     super::VarLenType::Udt => todo!(),
+                    //     super::VarLenType::Text => todo!(),
+                    //     super::VarLenType::Image => todo!(),
+                    //     super::VarLenType::NText => todo!(),
+                    //     super::VarLenType::SSVariant => todo!(),
+                    // },
+                    _ => None,
+                };
+            if let Some(ty) = ty_replace {
+                mdc.base.ty = ty;
+            }
+        }
+        TypeInfoTvp {
+            columns: Some(metadata),
+            ..self
+        }
+    }
+}

--- a/src/tds/stream.rs
+++ b/src/tds/stream.rs
@@ -1,5 +1,7 @@
+mod command;
 mod query;
 mod token;
 
+pub use command::*;
 pub use query::*;
 pub use token::*;

--- a/src/tds/stream/command.rs
+++ b/src/tds/stream/command.rs
@@ -1,0 +1,312 @@
+use crate::tds::stream::ReceivedToken;
+use crate::{row::ColumnType, Column, Row};
+use crate::{ColumnData, CommandResult, ResultMetadata};
+use futures_util::{
+    ready,
+    stream::{BoxStream, Peekable, Stream, StreamExt, TryStreamExt},
+};
+use std::{
+    fmt::Debug,
+    pin::Pin,
+    sync::Arc,
+    task::{self, Poll},
+};
+
+/// A set of `Streams` of [`CommandItem`] values, which can be either result
+/// metadata, row, return status, return value, etc.
+///
+/// # Example
+///
+/// ```no_run
+/// # use futures::TryStreamExt;
+/// # use tiberius::{numeric::Numeric, Client, Command};
+/// # use tokio::net::TcpStream;
+/// # use tokio_util::compat::TokioAsyncWriteCompatExt;
+/// # #[tokio::main]
+/// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// # let c_str = env::var("TIBERIUS_TEST_CONNECTION_STRING").unwrap_or(
+/// #     "server=tcp:localhost,1433;integratedSecurity=true;TrustServerCertificate=true".to_owned(),
+/// # );
+/// # let config = Config::from_ado_string(&c_str)?;
+/// # let tcp = tokio::net::TcpStream::connect(config.get_addr()).await?;
+/// # tcp.set_nodelay(true)?;
+/// # let mut client = tiberius::Client::connect(config, tcp.compat_write()).await?;
+/// let mut cmd = Command::new("dbo.usp_SomeStoredProc");
+///
+/// cmd.bind_param("@foo", 34i32);
+/// cmd.bind_param("@zoo", "the zoo string prm");
+/// cmd.bind_out_param("@bar", "bar");
+/// let stream = cmd.exec(&mut client).await?;
+///
+/// while let Some(item) = stream.try_next().await? {
+///     match item {
+///         // our first item is the column data always
+///         CommandItem::Metadata(meta) if meta.result_index() == 0 => {
+///             // the first result column info can be handled here
+///         }
+///         // ... and from there on from 0..N rows
+///         CommandItem::Row(row) if row.result_index() == 0 => {
+///             let var = row.get(0);
+///         }
+///         // the second result set returns first another metadata item
+///         CommandItem::Metadata(meta) => {
+///             // .. handling
+///         }
+///         // ...and, again, we get rows from the second resultset
+///         CommandItem::Row(row) => {
+///             let var = row.get(0);
+///         }
+///         // check return status (mandatory, returned always)
+///         CommandItem::ReturnStatus(rs) => {
+///             // .... do something
+///         }
+///         // check return status (mandatory, returned always)
+///         CommandItem::ReturnValue(rv) => {
+///             // .... do something, like push to a collection
+///         }
+///         // get affected row count
+///         CommandItem::RowsAffected(ra) => {
+///             // .... do something, like push to a collection
+///         }
+///     }
+/// }
+/// # Ok(())
+/// # }
+/// ```
+///
+pub struct CommandStream<'a> {
+    token_stream: Peekable<BoxStream<'a, crate::Result<ReceivedToken>>>,
+    columns: Option<Arc<Vec<Column>>>,
+    result_set_index: Option<usize>,
+}
+
+impl<'a> Debug for CommandStream<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CommandStream")
+            .field(
+                "token_stream",
+                &"BoxStream<'a, crate::Result<ReceivedToken>>",
+            )
+            .finish()
+    }
+}
+
+impl<'a> CommandStream<'a> {
+    pub(crate) fn new(token_stream: BoxStream<'a, crate::Result<ReceivedToken>>) -> Self {
+        Self {
+            token_stream: token_stream.peekable(),
+            columns: None,
+            result_set_index: None,
+        }
+    }
+
+    /// Collects all results from the command in the stream into memory in the order
+    /// of querying.
+    pub async fn into_command_result(mut self) -> crate::Result<CommandResult> {
+        let mut results: Vec<Vec<Row>> = Vec::new();
+        let mut result: Option<Vec<Row>> = None;
+        let mut return_status = 0;
+        let mut return_values = Vec::new();
+        let mut rows_affected = Vec::new();
+
+        while let Some(item) = self.try_next().await? {
+            match (item, &mut result) {
+                (CommandItem::Row(row), None) => {
+                    result = Some(vec![row]);
+                }
+                (CommandItem::Row(row), Some(ref mut result)) => result.push(row),
+                (CommandItem::Metadata(_), None) => {
+                    result = Some(Vec::new());
+                }
+                (CommandItem::Metadata(_), ref mut previous_result) => {
+                    results.push(previous_result.take().unwrap());
+                    result = None;
+                }
+                (CommandItem::ReturnStatus(rs), _) => return_status = rs,
+                (CommandItem::ReturnValue(rv), _) => return_values.push(rv),
+                (CommandItem::RowsAffected(rows), _) => rows_affected.push(rows),
+            }
+        }
+
+        if let Some(result) = result {
+            results.push(result);
+        }
+
+        Ok(CommandResult {
+            return_code: return_status,
+            return_values,
+            query_results: results,
+            rows_affected,
+        })
+    }
+
+    /// Convert the stream into a stream of rows, skipping all other items.
+    pub fn into_row_stream(self) -> BoxStream<'a, crate::Result<Row>> {
+        let s = self.try_filter_map(|item| async {
+            match item {
+                CommandItem::Row(row) => Ok(Some(row)),
+                _ => Ok(None),
+            }
+        });
+
+        Box::pin(s)
+    }
+}
+
+#[derive(Debug)]
+pub struct CommandReturnValue {
+    pub(crate) name: String,
+    pub(crate) _ord: u16, // TODO: remove? do we need it?
+    pub(crate) data: ColumnData<'static>,
+}
+
+/// Resulting data from a command.
+#[derive(Debug)]
+pub enum CommandItem {
+    /// A single row of data.
+    Row(Row),
+    /// Information of the upcoming row data.
+    Metadata(ResultMetadata),
+    /// Return Status from the server
+    ReturnStatus(u32),
+    /// Return Value, matching OUT parameter(s)
+    ReturnValue(CommandReturnValue),
+    /// Rows Affected, for one of the statements ran in server
+    RowsAffected(u64),
+}
+
+impl CommandItem {
+    pub(crate) fn metadata(columns: Arc<Vec<Column>>, result_index: usize) -> Self {
+        Self::Metadata(ResultMetadata {
+            columns,
+            result_index,
+        })
+    }
+
+    /// Returns a reference to the metadata, if the item is of a correct variant.
+    pub fn as_metadata(&self) -> Option<&ResultMetadata> {
+        match self {
+            CommandItem::Metadata(ref metadata) => Some(metadata),
+            _ => None,
+        }
+    }
+
+    /// Returns a reference to the row, if the item is of a correct variant.
+    pub fn as_row(&self) -> Option<&Row> {
+        match self {
+            CommandItem::Row(ref row) => Some(row),
+            _ => None,
+        }
+    }
+
+    /// Returns the metadata, if the item is of a correct variant.
+    pub fn into_metadata(self) -> Option<ResultMetadata> {
+        match self {
+            CommandItem::Metadata(metadata) => Some(metadata),
+            _ => None,
+        }
+    }
+
+    /// Returns the row, if the item is of a correct variant.
+    pub fn into_row(self) -> Option<Row> {
+        match self {
+            CommandItem::Row(row) => Some(row),
+            _ => None,
+        }
+    }
+
+    /// Returns the return status, if the item if on a correct variant.
+    pub fn as_return_status(&self) -> Option<u32> {
+        match self {
+            CommandItem::ReturnStatus(rs) => Some(*rs),
+            _ => None,
+        }
+    }
+
+    /// Returns the return value, if the item if on a correct variant.
+    pub fn as_return_value(&self) -> Option<&CommandReturnValue> {
+        match self {
+            CommandItem::ReturnValue(rv) => Some(rv),
+            _ => None,
+        }
+    }
+
+    /// Returns the return value, if the item if on a correct variant.
+    pub fn into_return_value(self) -> Option<CommandReturnValue> {
+        match self {
+            CommandItem::ReturnValue(rv) => Some(rv),
+            _ => None,
+        }
+    }
+}
+
+impl<'a> Stream for CommandStream<'a> {
+    type Item = crate::Result<CommandItem>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+
+        loop {
+            let token = match ready!(this.token_stream.poll_next_unpin(cx)) {
+                Some(res) => res?,
+                None => return Poll::Ready(None),
+            };
+
+            return match token {
+                ReceivedToken::NewResultset(meta) => {
+                    let column_meta = meta
+                        .columns
+                        .iter()
+                        .map(|x| Column {
+                            name: x.col_name.to_string(),
+                            column_type: ColumnType::from(&x.base.ty),
+                        })
+                        .collect::<Vec<_>>();
+
+                    let column_meta = Arc::new(column_meta);
+                    this.columns = Some(column_meta.clone());
+
+                    this.result_set_index = this.result_set_index.map(|i| i + 1);
+
+                    let query_item =
+                        CommandItem::metadata(column_meta, *this.result_set_index.get_or_insert(0));
+
+                    return Poll::Ready(Some(Ok(query_item)));
+                }
+                ReceivedToken::Row(data) => {
+                    let columns = this.columns.as_ref().unwrap().clone();
+                    let result_index = this.result_set_index.unwrap();
+
+                    let row = Row {
+                        columns,
+                        data,
+                        result_index,
+                    };
+
+                    Poll::Ready(Some(Ok(CommandItem::Row(row))))
+                }
+                ReceivedToken::ReturnStatus(rs) => {
+                    Poll::Ready(Some(Ok(CommandItem::ReturnStatus(rs))))
+                }
+                ReceivedToken::ReturnValue(rv) => {
+                    Poll::Ready(Some(Ok(CommandItem::ReturnValue(CommandReturnValue {
+                        name: rv.param_name,
+                        _ord: rv.param_ordinal,
+                        data: rv.value,
+                    }))))
+                }
+                ReceivedToken::DoneProc(done) if done.is_final() => continue,
+                ReceivedToken::DoneProc(done) => {
+                    Poll::Ready(Some(Ok(CommandItem::RowsAffected(done.rows()))))
+                }
+                ReceivedToken::DoneInProc(done) => {
+                    Poll::Ready(Some(Ok(CommandItem::RowsAffected(done.rows()))))
+                }
+                ReceivedToken::Done(done) => {
+                    Poll::Ready(Some(Ok(CommandItem::RowsAffected(done.rows()))))
+                }
+                _ => continue,
+            };
+        }
+    }
+}

--- a/src/tds/stream/command.rs
+++ b/src/tds/stream/command.rs
@@ -18,9 +18,10 @@ use std::{
 /// # Example
 ///
 /// ```no_run
-/// # use futures::TryStreamExt;
-/// # use tiberius::{numeric::Numeric, Client, Command};
-/// # use tokio::net::TcpStream;
+/// # use std::env;
+/// # use tiberius::Config;
+/// # use tiberius::{Command, CommandItem};
+/// # use futures_util::TryStreamExt;
 /// # use tokio_util::compat::TokioAsyncWriteCompatExt;
 /// # #[tokio::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -36,7 +37,7 @@ use std::{
 /// cmd.bind_param("@foo", 34i32);
 /// cmd.bind_param("@zoo", "the zoo string prm");
 /// cmd.bind_out_param("@bar", "bar");
-/// let stream = cmd.exec(&mut client).await?;
+/// let mut stream = cmd.exec(&mut client).await?;
 ///
 /// while let Some(item) = stream.try_next().await? {
 ///     match item {
@@ -46,7 +47,7 @@ use std::{
 ///         }
 ///         // ... and from there on from 0..N rows
 ///         CommandItem::Row(row) if row.result_index() == 0 => {
-///             let var = row.get(0);
+///             let var: Option<i32> = row.get(0);
 ///         }
 ///         // the second result set returns first another metadata item
 ///         CommandItem::Metadata(meta) => {
@@ -54,7 +55,7 @@ use std::{
 ///         }
 ///         // ...and, again, we get rows from the second resultset
 ///         CommandItem::Row(row) => {
-///             let var = row.get(0);
+///             let var: Option<i32> = row.get(0);
 ///         }
 ///         // check return status (mandatory, returned always)
 ///         CommandItem::ReturnStatus(rs) => {

--- a/src/tds/stream/query.rs
+++ b/src/tds/stream/query.rs
@@ -280,8 +280,8 @@ impl<'a> QueryStream<'a> {
 /// Info about the following stream of rows.
 #[derive(Debug, Clone)]
 pub struct ResultMetadata {
-    columns: Arc<Vec<Column>>,
-    result_index: usize,
+    pub(crate) columns: Arc<Vec<Column>>,
+    pub(crate) result_index: usize,
 }
 
 impl ResultMetadata {

--- a/src/tds/time/chrono.rs
+++ b/src/tds/time/chrono.rs
@@ -81,7 +81,7 @@ from_sql!(
             let offset = chrono::Duration::minutes(dto.offset as i64);
             let naive = NaiveDateTime::new(date, time).sub(offset);
 
-            chrono::DateTime::from_utc(naive, Utc)
+            chrono::DateTime::from_naive_utc_and_offset(naive, Utc)
         });
     chrono::DateTime<FixedOffset>: ColumnData::DateTimeOffset(ref dto) => dto.map(|dto| {
         let date = from_days(dto.datetime2.date.days() as i64, 1);
@@ -91,7 +91,7 @@ from_sql!(
         let offset = FixedOffset::east_opt((dto.offset as i32) * 60).unwrap();
         let naive = NaiveDateTime::new(date, time);
 
-        chrono::DateTime::from_utc(naive, offset)
+        chrono::DateTime::from_naive_utc_and_offset(naive, offset)
     })
 );
 

--- a/src/tds/time/time.rs
+++ b/src/tds/time/time.rs
@@ -7,7 +7,7 @@
 pub use time::*;
 
 use crate::tds::codec::ColumnData;
-use std::time::Duration;
+pub use std::time::Duration;
 
 #[inline]
 fn from_days(days: u64, start_year: i32) -> Date {

--- a/tests/command.rs
+++ b/tests/command.rs
@@ -1,14 +1,12 @@
 use futures_util::io::{AsyncRead, AsyncWrite};
-use futures_util::stream::TryStreamExt;
+// use futures_util::stream::TryStreamExt;
 use names::{Generator, Name};
 use once_cell::sync::Lazy;
 use std::cell::RefCell;
 use std::env;
 use std::sync::Once;
 
-use tiberius::FromSql;
-use tiberius::{numeric::Numeric, xml::XmlData, ColumnType, Command, CommandItem, Result};
-use uuid::Uuid;
+use tiberius::{Command, Result};
 
 use runtimes_macro::test_on_runtimes;
 

--- a/tests/command.rs
+++ b/tests/command.rs
@@ -113,7 +113,6 @@ where
     let proc_get = random_table().await;
 
     conn.simple_query("BEGIN TRAN").await?;
-
     conn.simple_query(format!(
         r#"if not exists(select * from sys.types where name = 'GeoTest')
             create type dbo.[GeoTest] as table
@@ -125,6 +124,7 @@ where
         "#
     ))
     .await?;
+    conn.simple_query("COMMIT").await?;
 
     conn.simple_query(format!(
         r#"
@@ -224,8 +224,6 @@ where
     let lon: Numeric = rows[0].get("lon").unwrap();
     assert_eq!(Numeric::new_with_scale(141, 6), lon);
     assert_eq!(Numeric::new_with_scale(192, 6), lat);
-
-    conn.simple_query("COMMIT").await?;
 
     Ok(())
 }

--- a/tests/command.rs
+++ b/tests/command.rs
@@ -1,0 +1,87 @@
+use futures_util::io::{AsyncRead, AsyncWrite};
+use futures_util::stream::TryStreamExt;
+use names::{Generator, Name};
+use once_cell::sync::Lazy;
+use std::cell::RefCell;
+use std::env;
+use std::sync::Once;
+
+use tiberius::FromSql;
+use tiberius::{numeric::Numeric, xml::XmlData, ColumnType, Command, CommandItem, Result};
+use uuid::Uuid;
+
+use runtimes_macro::test_on_runtimes;
+
+// This is used in the testing macro :)
+#[allow(dead_code)]
+static LOGGER_SETUP: Once = Once::new();
+
+static CONN_STR: Lazy<String> = Lazy::new(|| {
+    env::var("TIBERIUS_TEST_CONNECTION_STRING").unwrap_or_else(|_| {
+        "server=tcp:localhost,1433;user=SA;password=<YourStrong@Passw0rd>;IntegratedSecurity=true;TrustServerCertificate=true".to_owned()
+    })
+});
+
+thread_local! {
+    static NAMES: RefCell<Option<Generator<'static>>> =
+    RefCell::new(None);
+}
+
+async fn random_table() -> String {
+    NAMES.with(|maybe_generator| {
+        maybe_generator
+            .borrow_mut()
+            .get_or_insert_with(|| Generator::with_naming(Name::Plain))
+            .next()
+            .unwrap()
+            .replace('-', "")
+    })
+}
+
+#[test_on_runtimes]
+async fn basic_proc_exec<S>(mut conn: tiberius::Client<S>) -> Result<()>
+where
+    S: AsyncRead + AsyncWrite + Unpin + Send,
+{
+    let table = random_table().await;
+    let proc = random_table().await;
+
+    conn.simple_query(format!(
+        r#"
+        create table ##{} (
+            id int identity(1,1),
+            other varchar(50),
+        )
+    "#,
+        table
+    ))
+    .await?;
+
+    conn.simple_query(format!(
+        r#"
+        create or alter procedure {} 
+          @Param1 varchar(50)
+        as
+            insert into ##{} (other)
+            values (@Param1)
+
+            return scope_identity()
+    "#,
+        proc, table,
+    ))
+    .await?;
+
+    let mut ins_cmd = Command::new(&proc);
+    ins_cmd.bind_param("@Param1", "some text");
+
+    let result = ins_cmd.exec(&mut conn).await?.into_command_result().await?;
+    assert_eq!(1, result.return_code());
+
+    let mut ins_cmd = Command::new(&proc);
+    ins_cmd.bind_param("@Param1", "another text");
+
+    let result = ins_cmd.exec(&mut conn).await?.into_command_result().await?;
+    assert_eq!(2, result.return_code());
+
+    Ok(())
+}

--- a/tests/command.rs
+++ b/tests/command.rs
@@ -6,7 +6,7 @@ use std::cell::RefCell;
 use std::env;
 use std::sync::Once;
 
-use tiberius::{Command, Result};
+use tiberius::{numeric::Numeric, Command, Result, TableValueRow};
 
 use runtimes_macro::test_on_runtimes;
 
@@ -50,7 +50,7 @@ where
             id int identity(1,1),
             other varchar(50),
         )
-    "#,
+        "#,
         table
     ))
     .await?;
@@ -64,7 +64,7 @@ where
             values (@Param1)
 
             return scope_identity()
-    "#,
+        "#,
         proc, table,
     ))
     .await?;
@@ -80,6 +80,148 @@ where
 
     let result = ins_cmd.exec(&mut conn).await?.into_command_result().await?;
     assert_eq!(2, result.return_code());
+
+    Ok(())
+}
+
+struct GeoTest {
+    id: i32,
+    lat: Numeric,
+    lon: Numeric,
+}
+
+impl<'a> TableValueRow<'a> for GeoTest {
+    fn bind_fields(&self, data_row: &mut tiberius::SqlTableDataRow<'a>) {
+        data_row.add_field(self.id);
+        data_row.add_field(self.lat);
+        data_row.add_field(self.lon);
+    }
+
+    fn get_db_type() -> &'static str {
+        "GeoTest"
+    }
+}
+
+#[test_on_runtimes]
+async fn tvp_proc_exec<S>(mut conn: tiberius::Client<S>) -> Result<()>
+where
+    S: AsyncRead + AsyncWrite + Unpin + Send,
+{
+    let table = random_table().await;
+    let proc_tvp = random_table().await;
+    let proc_ins = random_table().await;
+    let proc_get = random_table().await;
+
+    conn.simple_query(format!(
+        r#"if not exists(select * from sys.types where name = 'GeoTest')
+            create type dbo.[GeoTest] as table
+            (
+                [ID] int not null,
+                [lat] decimal(9,6),
+                [lon] decimal(9,6)
+            )
+        "#
+    ))
+    .await?;
+
+    conn.simple_query(format!(
+        r#"
+        create table ##{} (
+            id int not null,
+            lat decimal(9,6),
+            lon decimal(9,6),
+            n varchar(50)
+        )
+    "#,
+        table
+    ))
+    .await?;
+
+    conn.simple_query(format!(
+        r#"
+        create or alter procedure {} 
+          @id int,
+          @geo dbo.[GeoTest] readonly
+        as
+        update t set
+            [lat] = g.[lat],
+            [lon] = g.[lon]
+        from
+            ##{} t
+            inner join @geo g on g.id = t.id
+
+        "#,
+        proc_tvp, table,
+    ))
+    .await?;
+
+    conn.simple_query(format!(
+        r#"
+        create or alter procedure {} 
+          @id int,
+          @name varchar(50)
+        as
+            insert into ##{} (id, n)
+            values (@id, @name)
+
+        "#,
+        proc_ins, table,
+    ))
+    .await?;
+
+    conn.simple_query(format!(
+        r#"
+        create or alter procedure {} 
+          @id int,
+          @count int out
+        as
+          set @count = (select count(*) from ##{})
+          select * from ##{}
+        "#,
+        proc_get, table, table
+    ))
+    .await?;
+
+    let mut ins_cmd = Command::new(&proc_ins);
+    ins_cmd.bind_param("@id", 23);
+    ins_cmd.bind_param("@name", "the twenty three");
+
+    let result = ins_cmd.exec(&mut conn).await?.into_command_result().await?;
+    assert_eq!(0, result.return_code());
+
+    let g1 = GeoTest {
+        id: 23,
+        lon: Numeric::new_with_scale(141, 6),
+        lat: Numeric::new_with_scale(192, 6),
+    };
+    let g2 = GeoTest {
+        id: 78,
+        lon: Numeric::new_with_scale(1141, 6),
+        lat: Numeric::new_with_scale(8192, 6),
+    };
+    let tbl = vec![g1, g2];
+    let mut tvp_cmd = Command::new(&proc_tvp);
+    tvp_cmd.bind_param("@id", 23);
+    tvp_cmd.bind_table("@geo", tbl);
+
+    let result = tvp_cmd.exec(&mut conn).await?.into_command_result().await?;
+    assert_eq!(0, result.return_code());
+
+    let count = 0;
+    let mut get_cmd = Command::new(&proc_get);
+    get_cmd.bind_param("@id", 23);
+    get_cmd.bind_out_param("@count", count);
+
+    let result = get_cmd.exec(&mut conn).await?.into_command_result().await?;
+    assert_eq!(0, result.return_code());
+    let count: i32 = result.try_return_value("@count")?.unwrap();
+    assert_eq!(1, count);
+
+    let rows = result.to_query_result(0).unwrap();
+    let lat: Numeric = rows[0].get("lat").unwrap();
+    let lon: Numeric = rows[0].get("lon").unwrap();
+    assert_eq!(Numeric::new_with_scale(141, 6), lon);
+    assert_eq!(Numeric::new_with_scale(192, 6), lat);
 
     Ok(())
 }

--- a/tests/command.rs
+++ b/tests/command.rs
@@ -112,6 +112,8 @@ where
     let proc_ins = random_table().await;
     let proc_get = random_table().await;
 
+    conn.simple_query("BEGIN TRAN").await?;
+
     conn.simple_query(format!(
         r#"if not exists(select * from sys.types where name = 'GeoTest')
             create type dbo.[GeoTest] as table
@@ -222,6 +224,8 @@ where
     let lon: Numeric = rows[0].get("lon").unwrap();
     assert_eq!(Numeric::new_with_scale(141, 6), lon);
     assert_eq!(Numeric::new_with_scale(192, 6), lat);
+
+    conn.simple_query("COMMIT").await?;
 
     Ok(())
 }

--- a/tests/command.rs
+++ b/tests/command.rs
@@ -115,7 +115,7 @@ where
 
     conn.simple_query(format!(
         r#"
-            create type dbo.{} as table
+            create type dbo.[{}] as table
             (
                 [ID] int not null,
                 [lat] decimal(9,6),
@@ -143,7 +143,7 @@ where
         r#"
         create or alter procedure {} 
           @id int,
-          @geo dbo.{} readonly
+          @geo dbo.[{}] readonly
         as
         update t set
             [lat] = g.[lat],
@@ -204,7 +204,7 @@ where
     let tbl = vec![g1, g2];
     let mut tvp_cmd = Command::new(&proc_tvp);
     tvp_cmd.bind_param("@id", 23);
-    tvp_cmd.bind_table_with_dbtype("@geo", db_type, tbl);
+    tvp_cmd.bind_table_with_dbtype("@geo", &db_type, tbl);
 
     let result = tvp_cmd.exec(&mut conn).await?.into_command_result().await?;
     assert_eq!(0, result.return_code());

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -2237,7 +2237,7 @@ where
         .unwrap()
         .and_hms_opt(16, 20, 0)
         .unwrap();
-    let dt: DateTime<Utc> = DateTime::from_utc(naive, Utc);
+    let dt: DateTime<Utc> = DateTime::from_naive_utc_and_offset(naive, Utc);
 
     let row = conn
         .query("SELECT @P1", &[&dt])
@@ -2276,7 +2276,7 @@ where
         .unwrap();
 
     let fixed = FixedOffset::east_opt(3600 * 3).unwrap();
-    let dt: DateTime<FixedOffset> = DateTime::from_utc(naive, fixed);
+    let dt: DateTime<FixedOffset> = DateTime::from_naive_utc_and_offset(naive, fixed);
 
     let row = conn
         .query("SELECT @P1", &[&dt])
@@ -2314,7 +2314,7 @@ where
         .and_hms_opt(16, 20, 0)
         .unwrap();
     let fixed = FixedOffset::east_opt(3600 * 3).unwrap();
-    let dt: DateTime<FixedOffset> = DateTime::from_utc(naive, fixed);
+    let dt: DateTime<FixedOffset> = DateTime::from_naive_utc_and_offset(naive, fixed);
 
     let row = conn
         .query(format!("SELECT CAST('{}' AS datetimeoffset(7))", dt), &[])

--- a/tvp-macro/Cargo.toml
+++ b/tvp-macro/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "tvp-macro"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+syn = "^2"
+quote = "^1"
+proc-macro2 = "^1"
+
+[lib]
+proc-macro = true

--- a/tvp-macro/src/attr.rs
+++ b/tvp-macro/src/attr.rs
@@ -1,0 +1,45 @@
+pub(crate) struct FieldAttr {
+    pub colname: Option<String>,
+}
+
+impl FieldAttr {
+    pub(crate) fn parse(attrs: &[syn::Attribute]) -> Option<FieldAttr> {
+        let mut result = None;
+        for attr in attrs.iter() {
+            match attr.style {
+                syn::AttrStyle::Outer => {}
+                _ => continue,
+            }
+            let last_attr_path = attr
+                .path()
+                .segments
+                .last()
+                .expect("Expected at least one segment where #[segment[::segment*](..)]");
+            if (*last_attr_path).ident != "colname" {
+                continue;
+            }
+            let kv = match attr.meta {
+                syn::Meta::NameValue(ref kv) => kv,
+                _ if attr.path().is_ident("colname") => {
+                    panic!("Invalid #[colname] attribute, expected #[colname = \"SomeColName\"]")
+                }
+                _ => continue,
+            };
+            if result.is_some() {
+                panic!("Expected at most one #[colname] attribute");
+            }
+            if let syn::Expr::Lit(syn::ExprLit {
+                lit: syn::Lit::Str(ref s),
+                ..
+            }) = kv.value
+            {
+                result = Some(FieldAttr {
+                    colname: Some(s.value()),
+                });
+            } else {
+                panic!("Non-string literal value in #[colname] attribute");
+            }
+        }
+        result
+    }
+}

--- a/tvp-macro/src/lib.rs
+++ b/tvp-macro/src/lib.rs
@@ -1,0 +1,44 @@
+//! This is a utility macro crate used to generate trivial trait implementations used in rust-to-SQL data exchange
+extern crate proc_macro;
+
+#[macro_use]
+extern crate quote;
+#[macro_use]
+extern crate syn;
+
+use proc_macro::TokenStream;
+
+macro_rules! sp_quote {
+    ($($t:tt)*) => (quote_spanned!(proc_macro2::Span::call_site() => $($t)*))
+}
+
+mod attr;
+mod table_value_param;
+
+/// This macro generates a trivial implementation of the `TableValueRow` trait.
+/// # Applications
+/// Could be applied to structures that represent rows of a Table Value params.
+/// # Example
+/// ```rust,ignore
+/// # use tiberius::*;
+/// #[derive(TableValueRow)]
+/// pub struct SomeGeoList {
+///   #[colname = "SomeID"]
+///   pub id: i32,
+///   #[colname = "LastSyncIPGeoLat"]
+///   pub lat: Numeric,
+///   #[colname = "LastSyncIPGeoLong"]
+///   pub lon: Numeric,
+/// }
+/// ```
+#[proc_macro_derive(TableValueRow, attributes(colname))]
+pub fn table_value_param(input: TokenStream) -> TokenStream {
+    //println!("intput: {}", input.to_string());
+    let ast: syn::DeriveInput = syn::parse(input).expect("Couldn't parse item");
+    let result = match ast.data {
+        syn::Data::Enum(_) => panic!("n/a for enums, makes sense for structs only"),
+        syn::Data::Struct(ref s) => table_value_param::for_struct(&ast, &s.fields),
+        syn::Data::Union(_) => panic!("doesn't work with unions"),
+    };
+    result.into()
+}

--- a/tvp-macro/src/table_value_param.rs
+++ b/tvp-macro/src/table_value_param.rs
@@ -1,0 +1,176 @@
+use proc_macro2::TokenStream;
+use syn::punctuated::Punctuated;
+
+use crate::attr::FieldAttr;
+
+pub(crate) fn for_struct(ast: &syn::DeriveInput, fields: &syn::Fields) -> TokenStream {
+    match *fields {
+        syn::Fields::Named(ref fields) => {
+            table_value_param_impl(&ast, Some(&fields.named) /*, true*/)
+        }
+        _ => panic!("Only named fields are supported so far"), // syn::Fields::Unit => try_from_row_impl(&ast, None, false, variant),
+                                                               // syn::Fields::Unnamed(ref fields) => {
+                                                               //     try_from_row_impl(&ast, Some(&fields.unnamed), false, variant)
+                                                               // }
+    }
+}
+
+fn table_value_param_impl(
+    ast: &syn::DeriveInput,
+    fields: Option<&Punctuated<syn::Field, Token![,]>>,
+    // named: bool,
+) -> TokenStream {
+    let name = &ast.ident;
+    let (lt_impl, lt_struct) =
+        {
+            let mut lifetimes: Vec<&syn::Ident> = Vec::new();
+            for gp in ast.generics.params.iter() {
+                if let syn::GenericParam::Lifetime(ltp) = gp {
+                    lifetimes.push(&ltp.lifetime.ident);
+                }
+            }
+            if lifetimes.len() > 1 {
+                panic!(
+                "Only one lifetime specifier is supported for the structure. Found multiple: {}",
+                lifetimes.iter().map(|lt| lt.to_string()).collect::<Vec<_>>().join(", "));
+            }
+            if lifetimes.is_empty() {
+                (
+                    sp_quote!(<'query>),
+                    sp_quote!(), // "".parse::<proc_macro2::TokenStream>().unwrap(),
+                )
+            } else {
+                let lt = lifetimes[0];
+                let ts: proc_macro2::TokenStream = format!("< '{} >", lt).parse().unwrap();
+                (ts.clone(), ts)
+            }
+        };
+    // let unit = fields.is_none();
+    let empty = Default::default();
+    let fields: Vec<_> = fields
+        .unwrap_or(&empty)
+        .iter()
+        .map(|f| FieldExt::new(f))
+        .collect();
+    let col_names: Vec<_> = fields.iter().map(|f| f.get_col_name()).collect();
+    let _col_names = sp_quote!( #(#col_names),* ); // this comes later, TVPs for queries would need col names, while SPs do not
+    let col_binds: Vec<_> = fields.iter().map(|f| f.as_bind()).collect();
+    let col_binds = sp_quote!( #(#col_binds);*);
+    sp_quote! {
+        impl #lt_impl ::tiberius::TableValueRow #lt_impl for #name #lt_struct {
+            fn get_db_type() -> &'static str {
+                stringify!{ #name }
+            }
+
+            fn bind_fields(&self, data_row: &mut tiberius::SqlTableDataRow #lt_impl) {
+                #col_binds;
+            }
+        }
+    }
+}
+
+struct FieldExt {
+    attr: Option<FieldAttr>,
+    ident: syn::Ident,
+}
+
+impl FieldExt {
+    pub fn new(field: &syn::Field) -> FieldExt {
+        if let Some(ident) = field.ident.clone() {
+            FieldExt {
+                attr: FieldAttr::parse(&field.attrs),
+                ident,
+            }
+        } else {
+            panic!("Field ident is required");
+        }
+    }
+    pub(crate) fn get_col_name(&self) -> String {
+        if let Some(attr) = self.attr.as_ref() {
+            if let Some(colname) = attr.colname.as_ref() {
+                return colname.to_string();
+            }
+        }
+        self.ident.to_string()
+    }
+    pub(crate) fn as_bind(&self) -> TokenStream {
+        let name = &self.ident;
+        sp_quote!(data_row.add_field(self.#name))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::for_struct;
+
+    #[test]
+    fn basic_nolifetime() {
+        // just parse a struct
+        let ast: syn::DeriveInput = syn::parse_str(
+            r#"
+    pub struct SomeGeoList {
+        #[colname = "SomeID"]
+        pub id: i32,
+        #[colname = "LastSyncIPGeoLat"]
+        pub lat: Numeric, // decimal(9,6)
+        #[colname = "LastSyncIPGeoLong"]
+        pub lon: Numeric, // decimal(9,6)
+    }
+            "#,
+        )
+        .unwrap();
+        let result = match ast.data {
+            syn::Data::Enum(_) => panic!("n/a for enums, makes sense for structs only"),
+            syn::Data::Struct(ref s) => for_struct(&ast, &s.fields),
+            syn::Data::Union(_) => panic!("doesn't work with unions"),
+        };
+        let etalon = sp_quote!(
+            impl<'query> ::tiberius::TableValueRow<'query> for SomeGeoList {
+                fn get_db_type() -> &'static str {
+                    stringify! { SomeGeoList }
+                }
+                fn bind_fields(&self, data_row: &mut tiberius::SqlTableDataRow<'query>) {
+                    data_row.add_field(self.id);
+                    data_row.add_field(self.lat);
+                    data_row.add_field(self.lon);
+                }
+            }
+        );
+
+        assert_eq!(result.to_string(), etalon.to_string());
+    }
+
+    #[test]
+    fn basic_lifetime() {
+        let ast: syn::DeriveInput = syn::parse_str(
+            r#"
+    pub struct AnotherGeoList<'e> {
+        #[colname = "SomeID"]
+        pub id: i32,
+        #[colname = "SomeStr"]
+        pub s: &'e str,
+    }
+            "#,
+        )
+        .unwrap();
+        let result = match ast.data {
+            syn::Data::Enum(_) => panic!("n/a for enums, makes sense for structs only"),
+            syn::Data::Struct(ref s) => for_struct(&ast, &s.fields),
+            syn::Data::Union(_) => panic!("doesn't work with unions"),
+        };
+
+        let etalon = sp_quote!(
+            impl<'e> ::tiberius::TableValueRow<'e> for AnotherGeoList<'e> {
+                fn get_db_type() -> &'static str {
+                    stringify! { AnotherGeoList }
+                }
+                fn bind_fields(&self, data_row: &mut tiberius::SqlTableDataRow<'e>) {
+                    data_row.add_field(self.id);
+                    data_row.add_field(self.s);
+                }
+            }
+        );
+
+        assert_eq!(result.to_string(), etalon.to_string());
+    }
+}

--- a/tvp-macro/src/table_value_param.rs
+++ b/tvp-macro/src/table_value_param.rs
@@ -57,12 +57,12 @@ fn table_value_param_impl(
     let col_binds: Vec<_> = fields.iter().map(|f| f.as_bind()).collect();
     let col_binds = sp_quote!( #(#col_binds);*);
     sp_quote! {
-        impl #lt_impl tiberius::TableValueRow #lt_impl for #name #lt_struct {
+        impl #lt_impl ::tiberius::TableValueRow #lt_impl for #name #lt_struct {
             fn get_db_type() -> &'static str {
                 stringify!{ #name }
             }
 
-            fn bind_fields(&self, data_row: &mut tiberius::SqlTableDataRow #lt_impl) {
+            fn bind_fields(&self, data_row: &mut ::tiberius::SqlTableDataRow #lt_impl) {
                 #col_binds;
             }
         }
@@ -129,7 +129,7 @@ mod tests {
                 fn get_db_type() -> &'static str {
                     stringify! { SomeGeoList }
                 }
-                fn bind_fields(&self, data_row: &mut tiberius::SqlTableDataRow<'query>) {
+                fn bind_fields(&self, data_row: &mut ::tiberius::SqlTableDataRow<'query>) {
                     data_row.add_field(self.id);
                     data_row.add_field(self.lat);
                     data_row.add_field(self.lon);
@@ -164,7 +164,7 @@ mod tests {
                 fn get_db_type() -> &'static str {
                     stringify! { AnotherGeoList }
                 }
-                fn bind_fields(&self, data_row: &mut tiberius::SqlTableDataRow<'e>) {
+                fn bind_fields(&self, data_row: &mut ::tiberius::SqlTableDataRow<'e>) {
                     data_row.add_field(self.id);
                     data_row.add_field(self.s);
                 }

--- a/tvp-macro/src/table_value_param.rs
+++ b/tvp-macro/src/table_value_param.rs
@@ -57,12 +57,12 @@ fn table_value_param_impl(
     let col_binds: Vec<_> = fields.iter().map(|f| f.as_bind()).collect();
     let col_binds = sp_quote!( #(#col_binds);*);
     sp_quote! {
-        impl #lt_impl ::tiberius::TableValueRow #lt_impl for #name #lt_struct {
+        impl #lt_impl tiberius::TableValueRow #lt_impl for #name #lt_struct {
             fn get_db_type() -> &'static str {
                 stringify!{ #name }
             }
 
-            fn bind_fields(&self, data_row: &mut ::tiberius::SqlTableDataRow #lt_impl) {
+            fn bind_fields(&self, data_row: &mut tiberius::SqlTableDataRow #lt_impl) {
                 #col_binds;
             }
         }
@@ -125,11 +125,11 @@ mod tests {
             syn::Data::Union(_) => panic!("doesn't work with unions"),
         };
         let etalon = sp_quote!(
-            impl<'query> ::tiberius::TableValueRow<'query> for SomeGeoList {
+            impl<'query> tiberius::TableValueRow<'query> for SomeGeoList {
                 fn get_db_type() -> &'static str {
                     stringify! { SomeGeoList }
                 }
-                fn bind_fields(&self, data_row: &mut ::tiberius::SqlTableDataRow<'query>) {
+                fn bind_fields(&self, data_row: &mut tiberius::SqlTableDataRow<'query>) {
                     data_row.add_field(self.id);
                     data_row.add_field(self.lat);
                     data_row.add_field(self.lon);
@@ -160,11 +160,11 @@ mod tests {
         };
 
         let etalon = sp_quote!(
-            impl<'e> ::tiberius::TableValueRow<'e> for AnotherGeoList<'e> {
+            impl<'e> tiberius::TableValueRow<'e> for AnotherGeoList<'e> {
                 fn get_db_type() -> &'static str {
                     stringify! { AnotherGeoList }
                 }
-                fn bind_fields(&self, data_row: &mut ::tiberius::SqlTableDataRow<'e>) {
+                fn bind_fields(&self, data_row: &mut tiberius::SqlTableDataRow<'e>) {
                     data_row.add_field(self.id);
                     data_row.add_field(self.s);
                 }

--- a/tvp-macro/src/table_value_param.rs
+++ b/tvp-macro/src/table_value_param.rs
@@ -57,7 +57,7 @@ fn table_value_param_impl(
     let col_binds: Vec<_> = fields.iter().map(|f| f.as_bind()).collect();
     let col_binds = sp_quote!( #(#col_binds);*);
     sp_quote! {
-        impl #lt_impl ::tiberius::TableValueRow #lt_impl for #name #lt_struct {
+        impl #lt_impl tiberius::TableValueRow #lt_impl for #name #lt_struct {
             fn get_db_type() -> &'static str {
                 stringify!{ #name }
             }


### PR DESCRIPTION
SUBJ. No changes to existing code behavior, no changes to existing public API, just some extras to call stored procedures or UDFs directly.

There are also few minor fixes for test build issues caused by recent `time`/`chrono` deprecated methods use.

Some test issues still persist: 
- all SQL Server 2022 tests failing due to connectivity errors
- macos tests show build issues 

Both are not related to the changes included in this PR, might be something caused by other dependencies updates.
