### PR TITLE
Fix header type for SSPI response message

### DIFF
--- a/src/client/connection.rs
+++ b/src/client/connection.rs
@@ -332,7 +332,7 @@ impl<S: AsyncRead + AsyncWrite + Unpin + Send> Connection<S> {
                         event!(Level::TRACE, sspi_response_len = sspi_response.len());
 
                         let id = self.context.next_packet_id();
-                        let header = PacketHeader::login(id);
+                        let header = PacketHeader::sspi(id);
 
                         let token = TokenSspi::new(sspi_response);
                         self.send(header, token).await?;

--- a/src/tds/codec/header.rs
+++ b/src/tds/codec/header.rs
@@ -92,6 +92,14 @@ impl PacketHeader {
         }
     }
 
+    pub fn sspi(id: u8) -> Self {
+        Self {
+            ty: PacketType::Sspi,
+            status: PacketStatus::EndOfMessage,
+            ..Self::new(0, id)
+        }
+    }
+
     pub fn batch(id: u8) -> Self {
         Self {
             ty: PacketType::SQLBatch,


### PR DESCRIPTION
Hi! I am working on [WiltonDB](https://wiltondb.com/) that implements TDS protocol compatible with MSSQL. I've noticed the following problem with Tiberius TDS client:

When Windows Integrated auth is used, Tiberius sends NTLM response message with `0x10` (`LOGIN7`) header type. According to [TDS spec](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tds/dc57840a-d13b-43a1-aad3-5425afadbc0c), `0x11` (`SSPI Message`) header type must be used instead.

MSSQL seems to accept either of these header types. I've implemented [TDS SSPI login support in WiltonDB](https://github.com/wiltondb/wiltondb/issues/18), it requires correct message type in NTLM response. Windows Integrated auth there is currently compatible with Microsoft clients for MSSQL, but not compatible with Tiberius. Thus I suggest this fix.