### PR TITLE
Fix GSSAPI Kerberos Authentication in Debug Mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ uuid = "1.0"
 winauth = { version = "0.0.4", optional = true }
 
 [target.'cfg(unix)'.dependencies]
-libgssapi = { version = "0.4.5", optional = true, default-features = false }
+libgssapi = { version = "0.8.1", optional = true, default-features = false }
 
 [dependencies.async-native-tls]
 version = "0.4"


### PR DESCRIPTION
# Problem
When using AuthMethod::IntegratedSecurity on Windows, the library behaves just as you would expect. However, when I tried to run my code on a Linux machine with proper Kerberos authentication set up, I would always get the following panic message when run in debug mode (`cargo run --debug`):
```
thread 'tokio-runtime-worker' panicked at library\core\src\panicking.rs:220:5:
unsafe precondition(s) violated: slice::from_raw_parts requires the pointer to be aligned and non-null, and the total size of the slice not to exceed `isize::MAX`
``` 

# Solution

Due to changes in the standard library (see [https://stackoverflow.com/a/78504630](https://stackoverflow.com/a/78504630) ), it is possible for debug assertions in `core` and `std` to panic: These assertions now fire when compiled in debug mode, even if the precompiled standard library was compiled in release mode. This caused a panic when I tried to connect using AuthMethod::IntegratedSecurity on Linux when run in debug mode, but not in release mode.

After updating the dependency for libgssapi to the latest version from 0.4.5 to 0.8.1 (and making small adjustments in `src/client/connection.rs` to reflect the changes with proper initialization), this issue got fixed.