### PR TITLE
feat: added sspi ntlm without kerberos using sspi-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ winauth = { version = "0.0.4", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libgssapi = { version = "0.8.1", optional = true, default-features = false }
+sspi = { version = "0.18", optional = true }
 
 [dependencies.async-native-tls]
 version = "0.4"
@@ -202,3 +203,4 @@ bigdecimal = ["bigdecimal_"]
 rustls = ["tokio-rustls", "tokio-util", "rustls-pemfile", "rustls-native-certs"]
 native-tls = ["async-native-tls"]
 vendored-openssl = ["opentls"]
+sspi-rs = ["sspi"]

--- a/src/client/auth.rs
+++ b/src/client/auth.rs
@@ -29,7 +29,7 @@ impl Debug for SqlServerAuth {
 #[cfg(any(all(windows, feature = "winauth"), all(unix, feature = "sspi-rs"), doc))]
 #[cfg_attr(
     feature = "docs",
-    doc(any(all(windows, feature = "winauth"), all(unix, feature = "sspi-rs")))
+    doc(cfg(any(all(windows, feature = "winauth"), all(unix, feature = "sspi-rs"))))
 )]
 pub struct WindowsAuth {
     pub(crate) user: String,
@@ -40,7 +40,7 @@ pub struct WindowsAuth {
 #[cfg(any(all(windows, feature = "winauth"), all(unix, feature = "sspi-rs"), doc))]
 #[cfg_attr(
     feature = "docs",
-    doc(any(all(windows, feature = "winauth"), all(unix, feature = "sspi-rs")))
+    doc(cfg(any(all(windows, feature = "winauth"), all(unix, feature = "sspi-rs"))))
 )]
 impl Debug for WindowsAuth {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/src/client/auth.rs
+++ b/src/client/auth.rs
@@ -26,16 +26,22 @@ impl Debug for SqlServerAuth {
 }
 
 #[derive(Clone, PartialEq, Eq)]
-#[cfg(any(all(windows, feature = "winauth"), doc))]
-#[cfg_attr(feature = "docs", doc(all(windows, feature = "winauth")))]
+#[cfg(any(all(windows, feature = "winauth"), all(unix, feature = "sspi-rs"), doc))]
+#[cfg_attr(
+    feature = "docs",
+    doc(any(all(windows, feature = "winauth"), all(unix, feature = "sspi-rs")))
+)]
 pub struct WindowsAuth {
     pub(crate) user: String,
     pub(crate) password: String,
     pub(crate) domain: Option<String>,
 }
 
-#[cfg(any(all(windows, feature = "winauth"), doc))]
-#[cfg_attr(feature = "docs", doc(all(windows, feature = "winauth")))]
+#[cfg(any(all(windows, feature = "winauth"), all(unix, feature = "sspi-rs"), doc))]
+#[cfg_attr(
+    feature = "docs",
+    doc(any(all(windows, feature = "winauth"), all(unix, feature = "sspi-rs")))
+)]
 impl Debug for WindowsAuth {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("WindowsAuth")
@@ -52,8 +58,11 @@ pub enum AuthMethod {
     /// Authenticate directly with SQL Server.
     SqlServer(SqlServerAuth),
     /// Authenticate with Windows credentials.
-    #[cfg(any(all(windows, feature = "winauth"), doc))]
-    #[cfg_attr(feature = "docs", doc(cfg(all(windows, feature = "winauth"))))]
+    #[cfg(any(all(windows, feature = "winauth"), all(unix, feature = "sspi-rs"), doc))]
+    #[cfg_attr(
+        feature = "docs",
+        doc(any(all(windows, feature = "winauth"), all(unix, feature = "sspi-rs")))
+    )]
     Windows(WindowsAuth),
     /// Authenticate as the currently logged in user. On Windows uses SSPI and
     /// Kerberos on Unix platforms.
@@ -84,8 +93,8 @@ impl AuthMethod {
     }
 
     /// Construct a new Windows authentication configuration.
-    #[cfg(any(all(windows, feature = "winauth"), doc))]
-    #[cfg_attr(feature = "docs", doc(cfg(all(windows, feature = "winauth"))))]
+    #[cfg(any(all(windows, feature = "winauth"), all(unix, feature = "sspi-rs"), doc))]
+    #[cfg_attr(feature = "docs", doc(any(all(windows, feature = "winauth"), all(unix, feature = "sspi-rs"))))]
     pub fn windows(user: impl AsRef<str>, password: impl ToString) -> Self {
         let (domain, user) = match user.as_ref().find('\\') {
             Some(idx) => (Some(&user.as_ref()[..idx]), &user.as_ref()[idx + 1..]),

--- a/src/client/config.rs
+++ b/src/client/config.rs
@@ -314,6 +314,8 @@ pub(crate) trait ConfigString {
             Some(val) if val.to_lowercase() == "sspi" || Self::parse_bool(val)? => {
                 Ok(AuthMethod::Integrated)
             }
+            
+            // Should sspi-rs take over the default behaviour here if enabled?
             _ => Ok(AuthMethod::sql_server(user.unwrap_or(""), pw.unwrap_or(""))),
         }
     }

--- a/src/client/config.rs
+++ b/src/client/config.rs
@@ -317,7 +317,7 @@ pub(crate) trait ConfigString {
                 (None, None) => Ok(AuthMethod::Integrated),
                 // this maintains the existing default behaviour. we could also throw an error here too, 
                 // but that may break some edge case an existing user may be relying on
-                _ => Ok(AuthMethod::sql_server("", "")),
+                _ => Ok(AuthMethod::sql_server(user.unwrap_or(""), pw.unwrap_or(""))),
             },
             #[cfg(all(unix, feature = "integrated-auth-gssapi", not(feature = "sspi-rs")))]
             Some(val) if val.to_lowercase() == "sspi" || Self::parse_bool(val)? => {

--- a/src/client/config.rs
+++ b/src/client/config.rs
@@ -310,12 +310,20 @@ pub(crate) trait ConfigString {
                 (None, None) => Ok(AuthMethod::Integrated),
                 _ => Ok(AuthMethod::windows(user.unwrap_or(""), pw.unwrap_or(""))),
             },
-            #[cfg(feature = "integrated-auth-gssapi")]
+            #[cfg(all(unix, feature = "sspi-rs"))]
+            Some(val) if val.to_lowercase() == "sspi" || Self::parse_bool(val)? => match (user, pw) {
+                (Some(user), Some(pw)) => Ok(AuthMethod::windows(user, pw)),
+                #[cfg(feature = "integrated-auth-gssapi")]
+                (None, None) => Ok(AuthMethod::Integrated),
+                // this maintains the existing default behaviour. we could also throw an error here too, 
+                // but that may break some edge case an existing user may be relying on
+                _ => Ok(AuthMethod::sql_server("", "")),
+            },
+            #[cfg(all(unix, feature = "integrated-auth-gssapi", not(feature = "sspi-rs")))]
             Some(val) if val.to_lowercase() == "sspi" || Self::parse_bool(val)? => {
                 Ok(AuthMethod::Integrated)
             }
             
-            // Should sspi-rs take over the default behaviour here if enabled?
             _ => Ok(AuthMethod::sql_server(user.unwrap_or(""), pw.unwrap_or(""))),
         }
     }

--- a/src/client/config.rs
+++ b/src/client/config.rs
@@ -315,9 +315,7 @@ pub(crate) trait ConfigString {
                 (Some(user), Some(pw)) => Ok(AuthMethod::windows(user, pw)),
                 #[cfg(feature = "integrated-auth-gssapi")]
                 (None, None) => Ok(AuthMethod::Integrated),
-                // this maintains the existing default behaviour. we could also throw an error here too, 
-                // but that may break some edge case an existing user may be relying on
-                _ => Ok(AuthMethod::sql_server(user.unwrap_or(""), pw.unwrap_or(""))),
+                _ => Ok(AuthMethod::windows(user.unwrap_or(""), pw.unwrap_or(""))),
             },
             #[cfg(all(unix, feature = "integrated-auth-gssapi", not(feature = "sspi-rs")))]
             Some(val) if val.to_lowercase() == "sspi" || Self::parse_bool(val)? => {

--- a/src/client/connection.rs
+++ b/src/client/connection.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 use asynchronous_codec::Framed;
 use bytes::BytesMut;
-#[cfg(any(windows, feature = "integrated-auth-gssapi"))]
+#[cfg(any(windows, feature = "integrated-auth-gssapi", feature = "sspi-rs"))]
 use codec::TokenSspi;
 use futures_util::io::{AsyncRead, AsyncWrite};
 use futures_util::ready;
@@ -39,6 +39,12 @@ use task::Poll;
 use tracing::{event, Level};
 #[cfg(all(windows, feature = "winauth"))]
 use winauth::{windows::NtlmSspiBuilder, NextBytes};
+
+#[cfg(all(unix, feature = "sspi-rs"))]
+use sspi::{
+    builders::EmptyInitializeSecurityContext, AuthIdentity, BufferType, ClientRequestFlags,
+    CredentialUse, DataRepresentation, Ntlm, SecurityBuffer, Sspi, SspiImpl, Username,
+};
 
 /// A `Connection` is an abstraction between the [`Client`] and the server. It
 /// can be used as a `Stream` to fetch [`Packet`]s from and to `send` packets
@@ -120,7 +126,7 @@ impl<S: AsyncRead + AsyncWrite + Unpin + Send> Connection<S> {
         TokenStream::new(self).flush_done().await
     }
 
-    #[cfg(any(windows, feature = "integrated-auth-gssapi"))]
+    #[cfg(any(windows, feature = "integrated-auth-gssapi", feature = "sspi-rs"))]
     /// Flush the incoming token stream until receiving `SSPI` token.
     async fn flush_sspi(&mut self) -> crate::Result<TokenSspi> {
         TokenStream::new(self).flush_sspi().await
@@ -381,6 +387,83 @@ impl<S: AsyncRead + AsyncWrite + Unpin + Send> Connection<S> {
 
                 self.send(header, next_token).await?;
             }
+
+            #[cfg(all(unix, feature = "sspi-rs", not(all(windows, feature = "winauth"))))]
+            AuthMethod::Windows(auth) => {
+                let mut ntlm = Ntlm::new();
+
+                let username = Username::new(&auth.user, auth.domain.as_deref())
+                    .map_err(|e| sspi::Error::from(e))?;
+
+                let identity = AuthIdentity {
+                    username,
+                    password: auth.password.clone().into(),
+                };
+
+                let mut creds = ntlm
+                    .acquire_credentials_handle()
+                    .with_credential_use(CredentialUse::Outbound)
+                    .with_auth_data(&identity)
+                    .execute(&mut ntlm)?;
+
+                let spn = self.context.spn().to_string();
+
+                let mut input = vec![SecurityBuffer::new(Vec::new(), BufferType::Token)];
+                let mut output = vec![SecurityBuffer::new(Vec::new(), BufferType::Token)];
+
+                let mut builder = ntlm
+                    .initialize_security_context()
+                    .with_credentials_handle(&mut creds.credentials_handle)
+                    .with_context_requirements(
+                        ClientRequestFlags::CONFIDENTIALITY | ClientRequestFlags::ALLOCATE_MEMORY,
+                    )
+                    .with_target_data_representation(DataRepresentation::Native)
+                    .with_target_name(&spn)
+                    .with_input(&mut input)
+                    .with_output(&mut output);
+
+                let _ = ntlm
+                    .initialize_security_context_impl(&mut builder)?
+                    .resolve_to_result()?;
+
+                login_message.integrated_security(Some(output[0].buffer.clone()));
+                let id = self.context.next_packet_id();
+                self.send(PacketHeader::login(id), login_message).await?;
+                self = self.post_login_encryption(encryption);
+
+                let sspi_bytes = self.flush_sspi().await?;
+
+                let mut input = vec![SecurityBuffer::new(
+                    sspi_bytes.as_ref().to_vec(),
+                    BufferType::Token,
+                )];
+                let mut output = vec![SecurityBuffer::new(Vec::new(), BufferType::Token)];
+
+                let mut builder = ntlm
+                    .initialize_security_context()
+                    .with_credentials_handle(&mut creds.credentials_handle)
+                    .with_context_requirements(
+                        ClientRequestFlags::CONFIDENTIALITY | ClientRequestFlags::ALLOCATE_MEMORY,
+                    )
+                    .with_target_data_representation(DataRepresentation::Native)
+                    .with_target_name(&spn)
+                    .with_input(&mut input)
+                    .with_output(&mut output);
+
+                let _ = ntlm
+                    .initialize_security_context_impl(&mut builder)?
+                    .resolve_to_result()?;
+
+                event!(Level::TRACE, authenticate_len = output[0].buffer.len());
+
+                let id = self.context.next_packet_id();
+                self.send(
+                    PacketHeader::login(id),
+                    TokenSspi::new(output[0].buffer.clone()),
+                )
+                .await?;
+            }
+
             #[cfg(all(windows, feature = "winauth"))]
             AuthMethod::Windows(auth) => {
                 let spn = self.context.spn().to_string();

--- a/src/error.rs
+++ b/src/error.rs
@@ -55,7 +55,7 @@ pub enum Error {
         doc(cfg(all(unix, feature = "sspi-rs")))
     )]
     /// An error in the sspi-rs library.
-    #[error("sspi-rs Error {}", _0)]
+    #[error("sspi-rs Error: {}", _0)]
     SspiRs(String),
     #[error(
         "Server requested a connection to an alternative address: `{}:{}`",
@@ -168,7 +168,7 @@ impl From<libgssapi::error::Error> for Error {
 }
 
 #[cfg(all(unix, feature = "sspi-rs"))]
-impl From <sspi::Error> for Error {
+impl From<sspi::Error> for Error {
     fn from(err: sspi::Error) -> Self {
         Error::SspiRs(format!("{}", err))
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -48,6 +48,9 @@ pub enum Error {
     /// An error from the GSSAPI library.
     #[error("GSSAPI Error: {}", _0)]
     Gssapi(String),
+    /// An error in the sspi-rs library.
+    #[error("sspi-rs Error {}", _0)]
+    SspiRs(String),
     #[error(
         "Server requested a connection to an alternative address: `{}:{}`",
         host,
@@ -83,7 +86,7 @@ impl Error {
 
 impl From<uuid::Error> for Error {
     fn from(e: uuid::Error) -> Self {
-        Self::Conversion(format!("Error convertiong a Guid value {}", e).into())
+        Self::Conversion(format!("Error converting a Guid value {}", e).into())
     }
 }
 
@@ -155,5 +158,12 @@ impl From<connection_string::Error> for Error {
 impl From<libgssapi::error::Error> for Error {
     fn from(err: libgssapi::error::Error) -> Error {
         Error::Gssapi(format!("{}", err))
+    }
+}
+
+#[cfg(all(unix, feature = "sspi-rs"))]
+impl From <sspi::Error> for Error {
+    fn from(err: sspi::Error) -> Self {
+        Error::SspiRs(format!("{}", err))
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -48,6 +48,12 @@ pub enum Error {
     /// An error from the GSSAPI library.
     #[error("GSSAPI Error: {}", _0)]
     Gssapi(String),
+
+    #[cfg(any(all(unix, feature = "sspi-rs"), doc))]
+    #[cfg_attr(
+        feature = "docs",
+        doc(cfg(all(unix, feature = "sspi-rs")))
+    )]
     /// An error in the sspi-rs library.
     #[error("sspi-rs Error {}", _0)]
     SspiRs(String),

--- a/src/error.rs
+++ b/src/error.rs
@@ -168,6 +168,10 @@ impl From<libgssapi::error::Error> for Error {
 }
 
 #[cfg(all(unix, feature = "sspi-rs"))]
+#[cfg_attr(
+    feature = "docs",
+    doc(cfg(all(unix, feature = "sspi-rs")))
+)]
 impl From<sspi::Error> for Error {
     fn from(err: sspi::Error) -> Self {
         Error::SspiRs(format!("{}", err))

--- a/src/tds/codec/login.rs
+++ b/src/tds/codec/login.rs
@@ -187,7 +187,7 @@ impl<'a> LoginMessage<'a> {
         }
     }
 
-    #[cfg(any(all(unix, feature = "integrated-auth-gssapi"), windows))]
+    #[cfg(any(all(unix, any(feature = "integrated-auth-gssapi", feature = "sspi-rs")), windows))]
     pub fn integrated_security(&mut self, bytes: Option<Vec<u8>>) {
         if bytes.is_some() {
             self.option_flags_2.insert(OptionFlag2::IntegratedSecurity);

--- a/src/tds/codec/token/token_sspi.rs
+++ b/src/tds/codec/token/token_sspi.rs
@@ -12,7 +12,7 @@ impl AsRef<[u8]> for TokenSspi {
 }
 
 impl TokenSspi {
-    #[cfg(any(windows, all(unix, feature = "integrated-auth-gssapi")))]
+    #[cfg(any(windows, all(unix, any(feature = "integrated-auth-gssapi", feature = "sspi-rs"))))]
     pub fn new(bytes: Vec<u8>) -> Self {
         Self(bytes)
     }

--- a/src/tds/context.rs
+++ b/src/tds/context.rs
@@ -62,7 +62,7 @@ impl Context {
         self.spn = Some(format!("MSSQLSvc/{}:{}", host.as_ref(), port));
     }
 
-    #[cfg(any(windows, all(unix, feature = "integrated-auth-gssapi")))]
+    #[cfg(any(windows, all(unix, any(feature = "integrated-auth-gssapi", feature = "sspi-rs"))))]
     pub fn spn(&self) -> &str {
         self.spn.as_deref().unwrap_or("")
     }

--- a/src/tds/stream/token.rs
+++ b/src/tds/stream/token.rs
@@ -75,7 +75,7 @@ where
         }
     }
 
-    #[cfg(any(windows, feature = "integrated-auth-gssapi"))]
+    #[cfg(any(windows, feature = "integrated-auth-gssapi", feature = "sspi-rs"))]
     pub(crate) async fn flush_sspi(self) -> crate::Result<TokenSspi> {
         let mut stream = self.try_unfold();
         let mut last_error = None;


### PR DESCRIPTION
Tiberius currently doesn't support SSPI NTLM authentication on Linux/MacOS systems without using Kerberos. This limits the use of Tiberius in older or more restrictive environments operated by some companies.

This PR adds the `sspi-rs` feature. When enabled, Linux and MacOS users can use `AuthMethod::Windows` just like Windows users currently can. This is done through the optional dependency on [sspi-rs](https://github.com/Devolutions/sspi-rs). Enabling this feature on Windows currently does nothing, and does not overwrite the existing `winauth` behaviour.

There's no breaking changes with this PR (as far as I'm aware). I have tested these changes locally and was successfully able to authenticate with SSPI NTLM without Kerberos.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional SSPI-based authentication (sspi-rs) added, enabling SSPI/NTLM-style integrated security on Unix and aligning Unix and Windows authentication paths.
  * New feature flag to opt into Unix SSPI support for integrated-security scenarios.

* **Bug Fixes**
  * Improved SSPI-related error handling and fixed a typo in an error conversion message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->