### PR TITLE
fix(error): correct 'occured'/'occurr' typos in Error::Io

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -4,12 +4,12 @@ pub use std::io::ErrorKind as IoErrorKind;
 use std::{borrow::Cow, convert::Infallible, io};
 use thiserror::Error;
 
-/// A unified error enum that contains several errors that might occurr during
+/// A unified error enum that contains several errors that might occur during
 /// the lifecycle of this driver
 #[derive(Debug, Clone, Error, PartialEq, Eq)]
 pub enum Error {
-    #[error("An error occured during the attempt of performing I/O: {}", message)]
-    /// An error occured when performing I/O to the server.
+    #[error("An error occurred during the attempt of performing I/O: {}", message)]
+    /// An error occurred when performing I/O to the server.
     Io {
         /// A list specifying general categories of I/O error.
         kind: IoErrorKind,


### PR DESCRIPTION
`src/error.rs` had three spelling errors clustered around the `Error` enum:

- Doc comment on the enum: `might occurr during` → `might occur during`
- `thiserror` error message for `Error::Io`: `An error occured during the attempt of performing I/O` → `An error occurred ...`
- Doc comment on `Error::Io`: `An error occured when performing I/O` → `An error occurred when performing I/O`

The error message is user-visible whenever a tiberius client logs or formats an `Error::Io` (it's the `Display` impl produced by `thiserror`), so correcting it removes a visible spelling mistake from downstream applications.

`cargo check` (default features) and `cargo check --no-default-features --features rustls,tokio-util,sql-browser-tokio` both stay clean against current `main`.