### PR TITLE
fix: correct 'occured' typo in I/O error message

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -8,8 +8,8 @@ use thiserror::Error;
 /// the lifecycle of this driver
 #[derive(Debug, Clone, Error, PartialEq, Eq)]
 pub enum Error {
-    #[error("An error occured during the attempt of performing I/O: {}", message)]
-    /// An error occured when performing I/O to the server.
+    #[error("An error occurred during the attempt of performing I/O: {}", message)]
+    /// An error occurred when performing I/O to the server.
     Io {
         /// A list specifying general categories of I/O error.
         kind: IoErrorKind,


### PR DESCRIPTION
## Summary

Fixes a typo `occured` → `occurred` in the `Io` error variant of `src/error.rs`.

The fix touches the user-facing `Display` string produced by the `#[error(...)]` attribute (shown to anyone who prints or logs this error), plus the matching doc comment one line above:

```rust
#[error("An error occurred during the attempt of performing I/O: {}", message)]
/// An error occurred when performing I/O to the server.
```

No behavior change — spelling only.
